### PR TITLE
Fix P&L, Balance Sheet, and Ageing report response handling

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -6,10 +6,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getApiClient } from '../api/client.js';
 import type {
-  ProfitAndLossReport,
-  BalanceSheetReport,
   VatObligation,
-  AgeingReport,
   ChartOfAccountsEntry,
 } from '../types/quickfile.js';
 import { handleToolError, successResult, type ToolResult } from './utils.js';
@@ -110,12 +107,48 @@ export const reportTools: Tool[] = [
 // Tool Handlers
 // =============================================================================
 
+// Actual API response structures (not wrapped in Report property)
 interface ProfitLossResponse {
-  Report: ProfitAndLossReport;
+  Totals: {
+    Turnover: number;
+    LessCostofSales: number;
+    LessExpenses: number;
+    NetProfit: number;
+  };
+  Breakdown: {
+    Turnover?: {
+      Balances?: {
+        Balance?: Array<{
+          NominalCode: number;
+          NominalAccountName: string;
+          Amount: number;
+        }>;
+      };
+    };
+    LessCostofSales?: {
+      Balances?: {
+        Balance?: Array<{
+          NominalCode: number;
+          NominalAccountName: string;
+          Amount: number;
+        }>;
+      };
+    };
+    LessExpenses?: {
+      Balances?: {
+        Balance?: Array<{
+          NominalCode: number;
+          NominalAccountName: string;
+          Amount: number;
+        }>;
+      };
+    };
+  };
 }
 
 interface BalanceSheetResponse {
-  Report: BalanceSheetReport;
+  // Balance Sheet response structure - to be determined from actual API response
+  [key: string]: unknown;
 }
 
 interface VatObligationsResponse {
@@ -125,7 +158,8 @@ interface VatObligationsResponse {
 }
 
 interface AgeingReportResponse {
-  Report: AgeingReport;
+  // Ageing Report response structure - to be determined from actual API response
+  [key: string]: unknown;
 }
 
 interface ChartOfAccountsResponse {
@@ -174,7 +208,7 @@ export async function handleReportTool(
           SearchParameters: searchParams,
         });
 
-        return successResult(response.Report);
+        return successResult(response);
       }
 
       case 'quickfile_report_balance_sheet': {
@@ -189,7 +223,7 @@ export async function handleReportTool(
           SearchParameters: searchParams,
         });
 
-        return successResult(response.Report);
+        return successResult(response);
       }
 
       case 'quickfile_report_vat_obligations': {
@@ -237,7 +271,7 @@ export async function handleReportTool(
           AsAtDate: reportDate,
         });
 
-        return successResult(response.Report);
+        return successResult(response);
       }
 
       case 'quickfile_report_chart_of_accounts': {


### PR DESCRIPTION
I am a novice in terms of using Git so my apologies in advance but I wanted to try and give something back towards the assistance that this tool has given so far.

To that end this PR attempts to fix a bug in the report endpoints where the QuickFile API response was being incorrectly parsed. (Presenting Error: "invalid_union")

Problem:

The QuickFile API returns report data directly in the response body, not wrapped in a "Report" property. This was causing the MCP server to return 'undefined' instead of the actual report data, which violated the MCP protocol requirement that content[].text must be a string.

Solution:

- Updated ProfitLossResponse interface to match actual API structure (with Totals and Breakdown properties)
- Updated BalanceSheetResponse and AgeingReportResponse to use flexible types
- Removed incorrect .Report property access in all three report handlers
- Removed unused type imports (ProfitAndLossReport, BalanceSheetReport, AgeingReport)

Tested with actual QuickFile API calls:
- P&L report: ✅ Working correctly
- Balance Sheet report: ✅ Working correctly

This fix should allow the P&L, Balance Sheet and Ageing reports to work correctly in Claude-Code and other MCP clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal report API response handling to enhance consistency and streamline data processing for profit/loss, balance sheet, and ageing reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->