### PR TITLE
fix: sync package.json version to 1.0.2 and add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-03-01
+
+### Fixed
+
+- **Version sync**: package.json version now matches README badge (1.0.2)
+- **README tool count**: Confirmed 37 MCP tools (previously claimed 40+, corrected in PR #8)
+
 ## [1.0.1] - 2025-12-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickfile-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for QuickFile UK accounting software - invoices, clients, purchases, banking, and reports",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.0.1` to `1.0.2` to match the README version badge
- Adds `CHANGELOG.md` entry for 1.0.2 documenting the version sync and tool count correction
- README tool count was already corrected from "40+" to "37" in PR #8

## Verification

- `npm run typecheck` — clean
- `npm test` — 201/201 tests pass

Closes #11