### PR TITLE
ci: add secretlint to CI workflow to prevent secret leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check for secrets
+        run: npm run secretlint
+
       - name: Type check
         run: npm run typecheck
 
@@ -39,6 +42,7 @@ jobs:
       - name: Test Summary
         run: |
           echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "- Secretlint: Passed" >> $GITHUB_STEP_SUMMARY
           echo "- TypeScript: Passed" >> $GITHUB_STEP_SUMMARY
           echo "- ESLint: Passed" >> $GITHUB_STEP_SUMMARY
           echo "- Unit Tests: Passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Adds a `secretlint` step to the CI workflow, running immediately after dependency installation and before type checking/linting
- Adds secretlint to the Test Summary step output
- Uses the existing `npm run secretlint` script (which runs `secretlint "**/*"` with the preset-recommend ruleset)

The repo already had secretlint fully configured locally (`.secretlintrc.json`, `.secretlintignore`, npm scripts, pre-commit hook) but it was not enforced in CI — meaning PRs could merge with accidental credential commits if the contributor skipped the local hook.

Closes #12