### PR TITLE
t019: sync package-lock.json version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickfile-mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickfile-mcp",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary

- Syncs `package-lock.json` version (`1.0.2` -> `1.0.3`) to match `package.json` (`1.0.3`)
- Addresses PR #10 review feedback from Gemini Code Assist flagging the version mismatch
- Regenerated lockfile via `npm install` — no dependency changes, only the 2 version fields

Closes #19