### PR TITLE
fix: replace placeholder index signatures with typed report response interfaces

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -115,15 +115,19 @@ export const reportTools: Tool[] = [
 
 // Actual API response structures (not wrapped in Report property)
 
-interface ProfitLossBalanceEntry {
-  NominalCode: number;
+// Shared structure for nominal balance line items used across P&L and Balance Sheet.
+// NominalCode is number in P&L responses but string (or null) in Balance Sheet.
+interface NominalBalance {
+  NominalCode: number | string | null;
   NominalAccountName: string;
   Amount: number;
 }
 
-interface ProfitLossBreakdownSection {
+// Shared breakdown section — each category in P&L and Balance Sheet uses this
+// nested Balances > Balance[] pattern. Sections can be null when empty.
+interface BalancesSection {
   Balances?: {
-    Balance?: ProfitLossBalanceEntry[];
+    Balance?: NominalBalance[];
   };
 }
 
@@ -135,16 +139,29 @@ interface ProfitLossResponse {
     NetProfit: number;
   };
   Breakdown: {
-    Turnover?: ProfitLossBreakdownSection;
-    LessCostofSales?: ProfitLossBreakdownSection;
-    LessExpenses?: ProfitLossBreakdownSection;
+    Turnover?: BalancesSection | null;
+    LessCostofSales?: BalancesSection | null;
+    LessExpenses?: BalancesSection | null;
   };
 }
 
+// Balance Sheet uses the same Totals + Breakdown pattern as P&L, with five
+// sections matching the standard UK balance sheet layout.
 interface BalanceSheetResponse {
-  // TODO: Define the actual structure for the Balance Sheet API response to improve type safety.
-  // Requires capturing a real API response to determine the exact shape.
-  [key: string]: unknown;
+  Totals: {
+    FixedAssets: number;
+    CurrentAssets: number;
+    CurrentLiabilities: number;
+    LongTermLiabilities: number;
+    CapitalAndReserves: number;
+  };
+  Breakdown: {
+    FixedAssets?: BalancesSection | null;
+    CurrentAssets?: BalancesSection | null;
+    CurrentLiabilities?: BalancesSection | null;
+    LongTermLiabilities?: BalancesSection | null;
+    CapitalAndReserves?: BalancesSection | null;
+  };
 }
 
 interface VatObligationsResponse {
@@ -153,10 +170,40 @@ interface VatObligationsResponse {
   };
 }
 
+// Ageing bucket totals shared by both creditor (supplier) and debtor (client) entries
+interface AgeingBucketTotals {
+  Prepayments: number;
+  TotalOverdue: number;
+  NotYetDue: number;
+  Aged_0_15: number;
+  Aged_16_30: number;
+  Aged_31_60: number;
+  Aged_61_90: number;
+  Aged_Over90: number;
+}
+
+interface AgeingSupplierEntry {
+  SupplierName: string;
+  SupplierID: number;
+  Totals: AgeingBucketTotals;
+}
+
+interface AgeingClientEntry {
+  ClientName: string;
+  ClientID: number;
+  Totals: AgeingBucketTotals;
+}
+
+// CREDITOR reports return Suppliers; DEBTOR reports return Clients
 interface AgeingReportResponse {
-  // TODO: Define the actual structure for the Ageing Report API response to improve type safety.
-  // Requires capturing a real API response to determine the exact shape.
-  [key: string]: unknown;
+  RecordsetCount: number;
+  ReturnCount: number;
+  Suppliers?: {
+    Supplier?: AgeingSupplierEntry[];
+  };
+  Clients?: {
+    Client?: AgeingClientEntry[];
+  };
 }
 
 interface ChartOfAccountsResponse {


### PR DESCRIPTION
## Summary

- Extract shared `NominalBalance` and `BalancesSection` interfaces to eliminate repetitive inline type definitions in `ProfitLossResponse`
- Replace `[key: string]: unknown` placeholder in `BalanceSheetResponse` with typed `Totals` + `Breakdown` structure matching the actual QuickFile API v1.2 response (5 sections: FixedAssets, CurrentAssets, CurrentLiabilities, LongTermLiabilities, CapitalAndReserves)
- Replace `[key: string]: unknown` placeholder in `AgeingReportResponse` with typed structure including pagination fields and discriminated Suppliers/Clients entries with proper ageing bucket totals

## Context

Addresses all three medium-severity findings from the Gemini code review on PR #1:
1. **report.ts:147** — Repetitive `Balances > Balance[]` structure duplicated across three P&L breakdown sections
2. **report.ts:152** — `BalanceSheetResponse` used `[key: string]: unknown`, sacrificing type safety
3. **report.ts:163** — `AgeingReportResponse` used `[key: string]: unknown`, sacrificing type safety

Response structures were verified against the QuickFile API v1.2 sandbox sample responses.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — 201/201 tests pass

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data structures for financial reporting (Profit & Loss, Balance Sheet, and Ageing reports) to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->