### PR TITLE
refactor: improve report type safety in src/tools/report.ts

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -109,6 +109,17 @@ export const reportTools: Tool[] = [
 // =============================================================================
 
 // Actual API response structures (not wrapped in Report property)
+
+interface ProfitLossBreakdownSection {
+  Balances?: {
+    Balance?: Array<{
+      NominalCode: number;
+      NominalAccountName: string;
+      Amount: number;
+    }>;
+  };
+}
+
 interface ProfitLossResponse {
   Totals: {
     Turnover: number;
@@ -117,38 +128,15 @@ interface ProfitLossResponse {
     NetProfit: number;
   };
   Breakdown: {
-    Turnover?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
-    LessCostofSales?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
-    LessExpenses?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
+    Turnover?: ProfitLossBreakdownSection;
+    LessCostofSales?: ProfitLossBreakdownSection;
+    LessExpenses?: ProfitLossBreakdownSection;
   };
 }
 
 interface BalanceSheetResponse {
-  // Balance Sheet response structure - to be determined from actual API response
+  // TODO: Define the actual structure for the Balance Sheet API response to improve type safety.
+  // Requires capturing a real API response to determine the exact shape.
   [key: string]: unknown;
 }
 
@@ -159,7 +147,8 @@ interface VatObligationsResponse {
 }
 
 interface AgeingReportResponse {
-  // Ageing Report response structure - to be determined from actual API response
+  // TODO: Define the actual structure for the Ageing Report API response to improve type safety.
+  // Requires capturing a real API response to determine the exact shape.
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Addresses all 3 medium-severity quality-debt findings from PR #1 Gemini code review feedback.

Closes #21

## Changes

- **Extract `ProfitLossBreakdownSection` interface** — the repeated `Balances > Balance > Array<{NominalCode, NominalAccountName, Amount}>` structure was duplicated across `Turnover`, `LessCostofSales`, and `LessExpenses` in `ProfitLossResponse`. Extracted into a shared interface for maintainability.
- **Add TODO comments to `BalanceSheetResponse`** — the `[key: string]: unknown` index signature loses type safety. Added a TODO tracking the need to define the actual API response structure once captured from a real API call.
- **Add TODO comments to `AgeingReportResponse`** — same pattern as BalanceSheetResponse. Added a TODO for future type definition.

## Verification

- `npm run build` — clean
- `npm run typecheck` — clean
- `npm run lint` — clean
- Net change: -11 lines (18 added, 29 removed) — less code, same functionality, better maintainability