### PR TITLE
docs: improve Quick Start and generalize setup.sh for multiple MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Model Context Protocol server for [QuickFile UK](https://www.quickfile.co.uk/) accounting software - giving AI assistants full access to invoicing, clients, purchases, banking, and financial reporting.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-1.0.2-blue)](https://github.com/marcusquinn/quickfile-mcp/releases)
+[![Version](https://img.shields.io/badge/Version-1.0.3-blue)](https://github.com/marcusquinn/quickfile-mcp/releases)
 [![CI](https://github.com/marcusquinn/quickfile-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/marcusquinn/quickfile-mcp/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_quickfile-mcp&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_quickfile-mcp)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/a2777b7658f140e894037816a0ca3a9c)](https://app.codacy.com/gh/marcusquinn/quickfile-mcp/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
@@ -38,6 +38,8 @@ npm install
 npm run build
 ```
 
+Note your install path for step 3 (run `pwd` to see it). The built server is at `<your-path>/dist/index.js`.
+
 ### 2. Configure Credentials
 
 Create your QuickFile API credentials:
@@ -68,7 +70,7 @@ Or use the interactive setup script:
 
 ### 3. Add to Your MCP Client
 
-This server works with any MCP-compatible client. Add it to your client's configuration:
+This server works with any MCP-compatible client. Replace `/absolute/path/to/quickfile-mcp` below with the actual path from step 1 (the output of `pwd`).
 
 **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -77,7 +79,7 @@ This server works with any MCP-compatible client. Add it to your client's config
   "mcpServers": {
     "quickfile": {
       "command": "node",
-      "args": ["/path/to/quickfile-mcp/dist/index.js"]
+      "args": ["/absolute/path/to/quickfile-mcp/dist/index.js"]
     }
   }
 }
@@ -86,7 +88,7 @@ This server works with any MCP-compatible client. Add it to your client's config
 **Claude Code**:
 
 ```bash
-claude mcp add quickfile node /path/to/quickfile-mcp/dist/index.js
+claude mcp add quickfile node /absolute/path/to/quickfile-mcp/dist/index.js
 ```
 
 **OpenCode** (`~/.config/opencode/opencode.json`):
@@ -96,11 +98,17 @@ claude mcp add quickfile node /path/to/quickfile-mcp/dist/index.js
   "mcp": {
     "quickfile": {
       "type": "local",
-      "command": ["node", "/path/to/quickfile-mcp/dist/index.js"],
+      "command": ["node", "/absolute/path/to/quickfile-mcp/dist/index.js"],
       "enabled": true
     }
   }
 }
+```
+
+You can also use the setup script to configure your client automatically:
+
+```bash
+./setup.sh client
 ```
 
 ### 4. Start Using

--- a/setup.sh
+++ b/setup.sh
@@ -8,11 +8,12 @@
 # Commands:
 #   install     - Install dependencies and build
 #   configure   - Configure credentials interactively
-#   opencode    - Add to OpenCode configuration
+#   client      - Add to MCP client configuration (interactive)
+#   opencode    - Add to OpenCode configuration (legacy alias)
 #   status      - Show current configuration status
 #   help        - Show this help
 #
-# Version: 0.1.0
+# Version: 0.2.0
 # =============================================================================
 
 set -euo pipefail
@@ -22,6 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CREDENTIALS_DIR="$HOME/.config/.quickfile-mcp"
 CREDENTIALS_FILE="$CREDENTIALS_DIR/credentials.json"
 OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
+CLAUDE_DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 
 # Colors
 RED='\033[0;31m'
@@ -31,124 +33,124 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 print_header() {
-    echo -e "${BLUE}========================================${NC}"
-    echo -e "${BLUE}  QuickFile MCP Server Setup${NC}"
-    echo -e "${BLUE}========================================${NC}"
-    echo ""
-    return 0
+	echo -e "${BLUE}========================================${NC}"
+	echo -e "${BLUE}  QuickFile MCP Server Setup${NC}"
+	echo -e "${BLUE}========================================${NC}"
+	echo ""
+	return 0
 }
 
 print_success() {
-    local message="$1"
-    echo -e "${GREEN}✓${NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${GREEN}✓${NC} ${message}"
+	return 0
 }
 
 print_warning() {
-    local message="$1"
-    echo -e "${YELLOW}⚠${NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${YELLOW}⚠${NC} ${message}"
+	return 0
 }
 
 print_error() {
-    local message="$1"
-    echo -e "${RED}✗${NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${RED}✗${NC} ${message}"
+	return 0
 }
 
 print_info() {
-    local message="$1"
-    echo -e "${BLUE}ℹ${NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${BLUE}ℹ${NC} ${message}"
+	return 0
 }
 
 check_requirements() {
-    local errors=0
+	local errors=0
 
-    # Check Node.js
-    if command -v node &>/dev/null; then
-        local node_version
-        node_version=$(node --version | sed 's/v//' | cut -d. -f1)
-        if [[ "$node_version" -ge 18 ]]; then
-            print_success "Node.js $(node --version) found"
-        else
-            print_error "Node.js 18+ required (found $(node --version))"
-            errors=$((errors + 1))
-        fi
-    else
-        print_error "Node.js not found"
-        errors=$((errors + 1))
-    fi
+	# Check Node.js
+	if command -v node &>/dev/null; then
+		local node_version
+		node_version=$(node --version | sed 's/v//' | cut -d. -f1)
+		if [[ "$node_version" -ge 18 ]]; then
+			print_success "Node.js $(node --version) found"
+		else
+			print_error "Node.js 18+ required (found $(node --version))"
+			errors=$((errors + 1))
+		fi
+	else
+		print_error "Node.js not found"
+		errors=$((errors + 1))
+	fi
 
-    # Check npm
-    if command -v npm &>/dev/null; then
-        print_success "npm $(npm --version) found"
-    else
-        print_error "npm not found"
-        errors=$((errors + 1))
-    fi
+	# Check npm
+	if command -v npm &>/dev/null; then
+		print_success "npm $(npm --version) found"
+	else
+		print_error "npm not found"
+		errors=$((errors + 1))
+	fi
 
-    return $errors
+	return $errors
 }
 
 install_dependencies() {
-    print_info "Installing dependencies..."
-    cd "$SCRIPT_DIR"
-    npm install
-    print_success "Dependencies installed"
-    return 0
+	print_info "Installing dependencies..."
+	cd "$SCRIPT_DIR"
+	npm install
+	print_success "Dependencies installed"
+	return 0
 }
 
 build_project() {
-    print_info "Building TypeScript..."
-    cd "$SCRIPT_DIR"
-    npm run build
-    print_success "Build complete"
-    return 0
+	print_info "Building TypeScript..."
+	cd "$SCRIPT_DIR"
+	npm run build
+	print_success "Build complete"
+	return 0
 }
 
 configure_credentials() {
-    print_header
-    echo "Configure QuickFile API Credentials"
-    echo ""
-    echo "You'll need the following from your QuickFile account:"
-    echo "  1. Account Number (visible in top-right of dashboard)"
-    echo "  2. API Key (Account Settings → 3rd Party Integrations)"
-    echo "  3. Application ID (Account Settings → Create a QuickFile App)"
-    echo ""
+	print_header
+	echo "Configure QuickFile API Credentials"
+	echo ""
+	echo "You'll need the following from your QuickFile account:"
+	echo "  1. Account Number (visible in top-right of dashboard)"
+	echo "  2. API Key (Account Settings → 3rd Party Integrations)"
+	echo "  3. Application ID (Account Settings → Create a QuickFile App)"
+	echo ""
 
-    # Create directory if needed
-    mkdir -p "$CREDENTIALS_DIR"
+	# Create directory if needed
+	mkdir -p "$CREDENTIALS_DIR"
 
-    # Read existing values if file exists
-    local existing_account=""
-    local existing_key=""
-    local existing_app=""
+	# Read existing values if file exists
+	local existing_account=""
+	local existing_key=""
+	local existing_app=""
 
-    if [[ -f "$CREDENTIALS_FILE" ]]; then
-        existing_account=$(grep -o '"accountNumber"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
-        existing_key=$(grep -o '"apiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
-        existing_app=$(grep -o '"applicationId"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
-    fi
+	if [[ -f "$CREDENTIALS_FILE" ]]; then
+		existing_account=$(grep -o '"accountNumber"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
+		existing_key=$(grep -o '"apiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
+		existing_app=$(grep -o '"applicationId"[[:space:]]*:[[:space:]]*"[^"]*"' "$CREDENTIALS_FILE" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/' || echo "")
+	fi
 
-    # Prompt for values
-    read -r -p "Account Number [$existing_account]: " account_number
-    account_number="${account_number:-$existing_account}"
+	# Prompt for values
+	read -r -p "Account Number [$existing_account]: " account_number
+	account_number="${account_number:-$existing_account}"
 
-    read -r -p "API Key [$existing_key]: " api_key
-    api_key="${api_key:-$existing_key}"
+	read -r -p "API Key [$existing_key]: " api_key
+	api_key="${api_key:-$existing_key}"
 
-    read -r -p "Application ID [$existing_app]: " application_id
-    application_id="${application_id:-$existing_app}"
+	read -r -p "Application ID [$existing_app]: " application_id
+	application_id="${application_id:-$existing_app}"
 
-    # Validate inputs
-    if [[ -z "$account_number" || -z "$api_key" || -z "$application_id" ]]; then
-        print_error "All fields are required"
-        return 1
-    fi
+	# Validate inputs
+	if [[ -z "$account_number" || -z "$api_key" || -z "$application_id" ]]; then
+		print_error "All fields are required"
+		return 1
+	fi
 
-    # Write credentials file
-    cat > "$CREDENTIALS_FILE" << EOF
+	# Write credentials file
+	cat >"$CREDENTIALS_FILE" <<EOF
 {
   "accountNumber": "$account_number",
   "apiKey": "$api_key",
@@ -156,65 +158,65 @@ configure_credentials() {
 }
 EOF
 
-    # Set secure permissions
-    chmod 600 "$CREDENTIALS_FILE"
+	# Set secure permissions
+	chmod 600 "$CREDENTIALS_FILE"
 
-    print_success "Credentials saved to $CREDENTIALS_FILE"
-    print_info "File permissions set to 600"
+	print_success "Credentials saved to $CREDENTIALS_FILE"
+	print_info "File permissions set to 600"
 
-    return 0
+	return 0
 }
 
 setup_opencode() {
-    print_info "Configuring OpenCode integration..."
+	print_info "Configuring OpenCode integration..."
 
-    # Check if OpenCode config exists
-    if [[ ! -f "$OPENCODE_CONFIG" ]]; then
-        print_warning "OpenCode config not found at $OPENCODE_CONFIG"
-        print_info "Creating minimal config..."
-        mkdir -p "$(dirname "$OPENCODE_CONFIG")"
-        echo '{"mcp": {}}' > "$OPENCODE_CONFIG"
-    fi
+	# Check if OpenCode config exists
+	if [[ ! -f "$OPENCODE_CONFIG" ]]; then
+		print_warning "OpenCode config not found at $OPENCODE_CONFIG"
+		print_info "Creating minimal config..."
+		mkdir -p "$(dirname "$OPENCODE_CONFIG")"
+		echo '{"mcp": {}}' >"$OPENCODE_CONFIG"
+	fi
 
-    # Check if jq is available
-    if ! command -v jq &>/dev/null; then
-        print_warning "jq not found - please add manually to $OPENCODE_CONFIG:"
-        echo ""
-        echo '  "mcp": {'
-        echo '    "quickfile": {'
-        echo '      "type": "local",'
-        echo "      \"command\": [\"node\", \"$SCRIPT_DIR/dist/index.js\"],"
-        echo '      "enabled": true'
-        echo '    }'
-        echo '  }'
-        echo ""
-        return 0
-    fi
+	# Check if jq is available
+	if ! command -v jq &>/dev/null; then
+		print_warning "jq not found - please add manually to $OPENCODE_CONFIG:"
+		echo ""
+		echo '  "mcp": {'
+		echo '    "quickfile": {'
+		echo '      "type": "local",'
+		echo "      \"command\": [\"node\", \"$SCRIPT_DIR/dist/index.js\"],"
+		echo '      "enabled": true'
+		echo '    }'
+		echo '  }'
+		echo ""
+		return 0
+	fi
 
-    # Add or update quickfile MCP configuration
-    local tmp_file
-    tmp_file=$(mktemp)
+	# Add or update quickfile MCP configuration
+	local tmp_file
+	tmp_file=$(mktemp)
 
-    jq --arg cmd "$SCRIPT_DIR/dist/index.js" '
+	jq --arg cmd "$SCRIPT_DIR/dist/index.js" '
         .mcp.quickfile = {
             "type": "local",
             "command": ["node", $cmd],
             "enabled": true
         }
-    ' "$OPENCODE_CONFIG" > "$tmp_file" && mv "$tmp_file" "$OPENCODE_CONFIG"
+    ' "$OPENCODE_CONFIG" >"$tmp_file" && mv "$tmp_file" "$OPENCODE_CONFIG"
 
-    print_success "OpenCode configuration updated"
-    print_info "Restart OpenCode to load the new MCP server"
+	print_success "OpenCode configuration updated"
+	print_info "Restart OpenCode to load the new MCP server"
 
-    return 0
+	return 0
 }
 
 create_opencode_agent() {
-    local opencode_agent_dir="$HOME/.config/opencode/agent"
-    mkdir -p "$opencode_agent_dir"
+	local opencode_agent_dir="$HOME/.config/opencode/agent"
+	mkdir -p "$opencode_agent_dir"
 
-    # Create agent file
-    cat > "$opencode_agent_dir/quickfile.md" << 'AGENT_EOF'
+	# Create agent file
+	cat >"$opencode_agent_dir/quickfile.md" <<'AGENT_EOF'
 ---
 description: QuickFile UK accounting - invoices, clients, purchases, banking, reports
 mode: subagent
@@ -246,68 +248,184 @@ Read `~/git/quickfile-mcp/AGENTS.md` for complete operational guidance.
 Credentials stored in `~/.config/.quickfile-mcp/credentials.json`
 AGENT_EOF
 
-    print_success "Created OpenCode agent at $opencode_agent_dir/quickfile.md"
-    return 0
+	print_success "Created OpenCode agent at $opencode_agent_dir/quickfile.md"
+	return 0
+}
+
+setup_claude_desktop() {
+	print_info "Configuring Claude Desktop..."
+
+	local config_dir
+	config_dir="$(dirname "$CLAUDE_DESKTOP_CONFIG")"
+
+	if [[ ! -d "$config_dir" ]]; then
+		print_warning "Claude Desktop config directory not found at $config_dir"
+		print_info "Creating directory..."
+		mkdir -p "$config_dir"
+	fi
+
+	if [[ ! -f "$CLAUDE_DESKTOP_CONFIG" ]]; then
+		echo '{}' >"$CLAUDE_DESKTOP_CONFIG"
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_warning "jq not found - please add manually to $CLAUDE_DESKTOP_CONFIG:"
+		echo ""
+		echo '  "mcpServers": {'
+		echo '    "quickfile": {'
+		echo '      "command": "node",'
+		echo "      \"args\": [\"$SCRIPT_DIR/dist/index.js\"]"
+		echo '    }'
+		echo '  }'
+		echo ""
+		return 0
+	fi
+
+	local tmp_file
+	tmp_file=$(mktemp)
+
+	jq --arg cmd "$SCRIPT_DIR/dist/index.js" '
+        .mcpServers.quickfile = {
+            "command": "node",
+            "args": [$cmd]
+        }
+    ' "$CLAUDE_DESKTOP_CONFIG" >"$tmp_file" && mv "$tmp_file" "$CLAUDE_DESKTOP_CONFIG"
+
+	print_success "Claude Desktop configuration updated"
+	print_info "Restart Claude Desktop to load the new MCP server"
+
+	return 0
+}
+
+setup_claude_code() {
+	print_info "Configuring Claude Code..."
+
+	if ! command -v claude &>/dev/null; then
+		print_warning "Claude Code CLI not found"
+		print_info "Install from: https://docs.anthropic.com/en/docs/claude-code"
+		print_info "Then run: claude mcp add quickfile node $SCRIPT_DIR/dist/index.js"
+		return 0
+	fi
+
+	claude mcp add quickfile node "$SCRIPT_DIR/dist/index.js"
+	print_success "Claude Code configuration updated"
+
+	return 0
+}
+
+setup_client() {
+	print_header
+	echo "Configure MCP Client Integration"
+	echo ""
+	echo "Which MCP client would you like to configure?"
+	echo ""
+	echo "  1) Claude Desktop"
+	echo "  2) Claude Code"
+	echo "  3) OpenCode"
+	echo "  4) All of the above"
+	echo ""
+
+	local choice
+	read -r -p "Select [1-4]: " choice
+
+	case "$choice" in
+	1)
+		setup_claude_desktop
+		;;
+	2)
+		setup_claude_code
+		;;
+	3)
+		setup_opencode
+		create_opencode_agent
+		;;
+	4)
+		setup_claude_desktop
+		echo ""
+		setup_claude_code
+		echo ""
+		setup_opencode
+		create_opencode_agent
+		;;
+	*)
+		print_error "Invalid choice: $choice"
+		return 1
+		;;
+	esac
+
+	return 0
 }
 
 show_status() {
-    print_header
+	print_header
 
-    # Check credentials
-    echo "Credentials:"
-    if [[ -f "$CREDENTIALS_FILE" ]]; then
-        local perms
-        perms=$(stat -f "%Lp" "$CREDENTIALS_FILE" 2>/dev/null || stat -c "%a" "$CREDENTIALS_FILE" 2>/dev/null)
-        if [[ "$perms" == "600" ]]; then
-            print_success "Credentials file exists with correct permissions (600)"
-        else
-            print_warning "Credentials file exists but permissions are $perms (should be 600)"
-        fi
+	# Check credentials
+	echo "Credentials:"
+	if [[ -f "$CREDENTIALS_FILE" ]]; then
+		local perms
+		perms=$(stat -f "%Lp" "$CREDENTIALS_FILE" 2>/dev/null || stat -c "%a" "$CREDENTIALS_FILE" 2>/dev/null)
+		if [[ "$perms" == "600" ]]; then
+			print_success "Credentials file exists with correct permissions (600)"
+		else
+			print_warning "Credentials file exists but permissions are $perms (should be 600)"
+		fi
 
-        # Check if credentials are complete
-        if grep -q '"accountNumber"' "$CREDENTIALS_FILE" && \
-           grep -q '"apiKey"' "$CREDENTIALS_FILE" && \
-           grep -q '"applicationId"' "$CREDENTIALS_FILE"; then
-            print_success "All credential fields present"
-        else
-            print_warning "Some credential fields may be missing"
-        fi
-    else
-        print_warning "Credentials file not found at $CREDENTIALS_FILE"
-    fi
+		# Check if credentials are complete
+		if grep -q '"accountNumber"' "$CREDENTIALS_FILE" &&
+			grep -q '"apiKey"' "$CREDENTIALS_FILE" &&
+			grep -q '"applicationId"' "$CREDENTIALS_FILE"; then
+			print_success "All credential fields present"
+		else
+			print_warning "Some credential fields may be missing"
+		fi
+	else
+		print_warning "Credentials file not found at $CREDENTIALS_FILE"
+	fi
 
-    echo ""
+	echo ""
 
-    # Check build
-    echo "Build Status:"
-    if [[ -f "$SCRIPT_DIR/dist/index.js" ]]; then
-        print_success "Built (dist/index.js exists)"
-    else
-        print_warning "Not built - run './setup.sh install'"
-    fi
+	# Check build
+	echo "Build Status:"
+	if [[ -f "$SCRIPT_DIR/dist/index.js" ]]; then
+		print_success "Built (dist/index.js exists)"
+	else
+		print_warning "Not built - run './setup.sh install'"
+	fi
 
-    echo ""
+	echo ""
 
-    # Check OpenCode
-    echo "OpenCode Integration:"
-    if [[ -f "$OPENCODE_CONFIG" ]] && grep -q "quickfile" "$OPENCODE_CONFIG" 2>/dev/null; then
-        print_success "Configured in OpenCode"
-    else
-        print_warning "Not configured in OpenCode - run './setup.sh opencode'"
-    fi
+	# Check MCP client integrations
+	echo "MCP Client Integrations:"
 
-    if [[ -f "$HOME/.config/opencode/agent/quickfile.md" ]]; then
-        print_success "Agent file exists"
-    else
-        print_warning "Agent file not found"
-    fi
+	# Claude Desktop
+	if [[ -f "$CLAUDE_DESKTOP_CONFIG" ]] && grep -q "quickfile" "$CLAUDE_DESKTOP_CONFIG" 2>/dev/null; then
+		print_success "Configured in Claude Desktop"
+	else
+		print_warning "Not configured in Claude Desktop"
+	fi
 
-    echo ""
-    return 0
+	# Claude Code
+	if command -v claude &>/dev/null; then
+		print_success "Claude Code CLI available"
+	else
+		print_warning "Claude Code CLI not found"
+	fi
+
+	# OpenCode
+	if [[ -f "$OPENCODE_CONFIG" ]] && grep -q "quickfile" "$OPENCODE_CONFIG" 2>/dev/null; then
+		print_success "Configured in OpenCode"
+	else
+		print_warning "Not configured in OpenCode"
+	fi
+
+	echo ""
+	print_info "Run './setup.sh client' to configure any MCP client"
+	echo ""
+	return 0
 }
 
 show_help() {
-    cat << 'HELP_EOF'
+	cat <<'HELP_EOF'
 QuickFile MCP Server - Setup Script
 
 Usage: ./setup.sh [command]
@@ -315,15 +433,16 @@ Usage: ./setup.sh [command]
 Commands:
   install     Install dependencies and build the project
   configure   Configure QuickFile API credentials interactively
-  opencode    Add MCP server to OpenCode configuration
+  client      Add MCP server to your client (Claude Desktop, Claude Code, OpenCode)
+  opencode    Add MCP server to OpenCode configuration (legacy, use 'client' instead)
   status      Show current configuration status
   help        Show this help message
 
 Quick Start:
   1. ./setup.sh install     # Install and build
   2. ./setup.sh configure   # Set up credentials
-  3. ./setup.sh opencode    # Configure OpenCode
-  4. Restart OpenCode
+  3. ./setup.sh client      # Configure your MCP client
+  4. Restart your MCP client
 
 Credentials are stored securely at:
   ~/.config/.quickfile-mcp/credentials.json
@@ -333,44 +452,47 @@ For more information:
   https://api.quickfile.co.uk/
 
 HELP_EOF
-    return 0
+	return 0
 }
 
 main() {
-    local command="${1:-help}"
+	local command="${1:-help}"
 
-    case "$command" in
-        install)
-            print_header
-            check_requirements || exit 1
-            install_dependencies
-            build_project
-            echo ""
-            print_success "Installation complete!"
-            print_info "Next: Run './setup.sh configure' to set up credentials"
-            ;;
-        configure)
-            configure_credentials
-            ;;
-        opencode)
-            print_header
-            setup_opencode
-            create_opencode_agent
-            ;;
-        status)
-            show_status
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            show_help
-            exit 1
-            ;;
-    esac
+	case "$command" in
+	install)
+		print_header
+		check_requirements || exit 1
+		install_dependencies
+		build_project
+		echo ""
+		print_success "Installation complete!"
+		print_info "Next: Run './setup.sh configure' to set up credentials"
+		;;
+	configure)
+		configure_credentials
+		;;
+	client)
+		setup_client
+		;;
+	opencode)
+		print_header
+		setup_opencode
+		create_opencode_agent
+		;;
+	status)
+		show_status
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		show_help
+		exit 1
+		;;
+	esac
 
-    return 0
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Addresses quality-debt from PR #8 Gemini review feedback: Quick Start instructions were incomplete for new users.

- **README**: Add path guidance after build step, clarify placeholder paths with explicit instructions to use `pwd`, reference `./setup.sh client` command, fix version badge (1.0.2 -> 1.0.3)
- **setup.sh**: Add `client` command with interactive multi-client support (Claude Desktop, Claude Code, OpenCode), update status checks to cover all clients, keep `opencode` as backward-compatible alias

### Verification

- 201 unit tests pass
- ESLint clean
- ShellCheck clean
- TypeScript build succeeds

Closes #20