### PR TITLE
fix: make VAT obligations error handling robust

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { getApiClient } from "../api/client.js";
+import { getApiClient, QuickFileApiError } from "../api/client.js";
 import type {
   VatObligation,
   ChartOfAccountsEntry,
@@ -257,14 +257,23 @@ export async function handleReportTool(
             count: obligations.length,
             obligations: obligations,
           });
-        } catch (_error) {
-          // If the account is not VAT registered or MTD not set up, return helpful message
-          return successResult({
-            count: 0,
-            obligations: [],
-            message:
-              "VAT obligations not available. This account may not be VAT registered or MTD VAT may not be configured.",
-          });
+        } catch (error) {
+          // Only handle VAT-specific errors gracefully; re-throw unexpected errors
+          // so the outer catch block can handle network/auth failures properly
+          if (
+            error instanceof QuickFileApiError &&
+            (error.message.includes("not VAT registered") ||
+              error.message.includes("MTD not configured") ||
+              error.message.includes("VAT"))
+          ) {
+            return successResult({
+              count: 0,
+              obligations: [],
+              message:
+                "VAT obligations not available. This account may not be VAT registered or MTD VAT may not be configured.",
+            });
+          }
+          throw error;
         }
       }
 


### PR DESCRIPTION
## Summary

- Addresses quality-debt from PR #16 review feedback (Gemini, medium severity)
- The VAT obligations catch block previously swallowed **all** errors (network, auth, timeout) and returned a success response with an informational message — hiding real failures
- Now inspects the error type: only `QuickFileApiError` instances with VAT-related messages are handled gracefully; all other errors are re-thrown to the outer `handleToolError()` for proper error reporting

## Changes

**`src/tools/report.ts`**:
- Import `QuickFileApiError` from `../api/client.js`
- Replace blanket `catch (_error)` with typed error inspection using `instanceof QuickFileApiError` and message pattern matching
- Non-VAT errors (`throw error`) propagate to the outer catch block at line 319

## Verification

- Build: `npm run build` -- clean
- Typecheck: `npm run typecheck` -- clean
- Lint: `npm run lint` -- clean (0 errors, 0 warnings)
- Tests: `npm test` -- 201 passed, 0 failed

Closes #17