### PR TITLE
refactor: extract ProfitLossBreakdownSection and add type safety TODOs

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -109,6 +109,17 @@ export const reportTools: Tool[] = [
 // =============================================================================
 
 // Actual API response structures (not wrapped in Report property)
+
+interface ProfitLossBreakdownSection {
+  Balances?: {
+    Balance?: Array<{
+      NominalCode: number;
+      NominalAccountName: string;
+      Amount: number;
+    }>;
+  };
+}
+
 interface ProfitLossResponse {
   Totals: {
     Turnover: number;
@@ -117,38 +128,15 @@ interface ProfitLossResponse {
     NetProfit: number;
   };
   Breakdown: {
-    Turnover?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
-    LessCostofSales?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
-    LessExpenses?: {
-      Balances?: {
-        Balance?: Array<{
-          NominalCode: number;
-          NominalAccountName: string;
-          Amount: number;
-        }>;
-      };
-    };
+    Turnover?: ProfitLossBreakdownSection;
+    LessCostofSales?: ProfitLossBreakdownSection;
+    LessExpenses?: ProfitLossBreakdownSection;
   };
 }
 
 interface BalanceSheetResponse {
-  // Balance Sheet response structure - to be determined from actual API response
+  // TODO: Define the actual structure for the Balance Sheet API response to improve type safety.
+  // Requires capturing a real API response to determine the exact shape.
   [key: string]: unknown;
 }
 
@@ -159,7 +147,8 @@ interface VatObligationsResponse {
 }
 
 interface AgeingReportResponse {
-  // Ageing Report response structure - to be determined from actual API response
+  // TODO: Define the actual structure for the Ageing Report API response to improve type safety.
+  // Requires capturing a real API response to determine the exact shape.
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Addresses quality-debt from PR #1 review feedback (Gemini Code Assist).

Closes #21

### Changes

- **Extract `ProfitLossBreakdownSection` interface** — The `Breakdown` property in `ProfitLossResponse` had identical nested structures for `Turnover`, `LessCostofSales`, and `LessExpenses`. Extracted into a shared interface to reduce duplication and improve maintainability.
- **Add TODO comments to `BalanceSheetResponse`** — The `[key: string]: unknown` index signature is a pragmatic placeholder. Added a `// TODO:` comment documenting that the actual API response structure should be defined once captured from a real API call.
- **Add TODO comments to `AgeingReportResponse`** — Same treatment as `BalanceSheetResponse`.

### Review Findings Addressed

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| 1 | medium | Repetitive `Breakdown` structure in `ProfitLossResponse` (line 147) | Fixed — extracted `ProfitLossBreakdownSection` |
| 2 | medium | `BalanceSheetResponse` uses `[key: string]: unknown` without TODO (line 152) | Fixed — added TODO comment |
| 3 | medium | `AgeingReportResponse` uses `[key: string]: unknown` without TODO (line 163) | Fixed — added TODO comment |

### Verification

- `npm run build` — passes
- `npm run lint` — passes
- No runtime behaviour changes — interfaces only affect compile-time type checking