### PR TITLE
docs: clarify retroactive tool count note in v1.0.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Version sync**: package.json version now matches README badge (1.0.2)
-- **README tool count**: Confirmed 37 MCP tools (previously claimed 40+, corrected in PR #8)
+
+### Documentation
+
+- **README tool count** (retroactive): Acknowledged correction from 37 to actual count, applied in PR #8 between v1.0.1 and v1.0.2 releases
 
 ## [1.0.1] - 2025-12-01
 


### PR DESCRIPTION
## Summary

- Moves the README tool count entry in the v1.0.2 changelog from the `Fixed` section to a new `Documentation` section with a `(retroactive)` label
- Makes it clear this acknowledges a correction applied in PR #8, not a code fix introduced in v1.0.2
- Addresses Gemini Code Assist review feedback from PR #13

## Context

The [Gemini review on PR #13](https://github.com/marcusquinn/quickfile-mcp/pull/13#discussion_r2868675978) flagged that the tool count entry was misleading — it documented a correction from PR #8 as if it were a fix introduced in v1.0.2. The reviewer recommended either amending the changelog for the version that included PR #8, or rephrasing to clarify it's a documentation correction.

Since PR #8 landed between the v1.0.1 and v1.0.2 tags (not part of either release), the most accurate approach is to keep the note in v1.0.2 but reclassify it as a retroactive documentation acknowledgement.

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the changelog for version 1.0.2, introducing a new Documentation subsection to better categorize documentation-related updates.
  * Corrected and clarified the README tool count documentation entry, reflecting the accurate value for the version 1.0.2 release period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->