### PR TITLE
refactor: extract ProfitLossBalanceEntry interface

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -110,13 +110,15 @@ export const reportTools: Tool[] = [
 
 // Actual API response structures (not wrapped in Report property)
 
+interface ProfitLossBalanceEntry {
+  NominalCode: number;
+  NominalAccountName: string;
+  Amount: number;
+}
+
 interface ProfitLossBreakdownSection {
   Balances?: {
-    Balance?: Array<{
-      NominalCode: number;
-      NominalAccountName: string;
-      Amount: number;
-    }>;
+    Balance?: ProfitLossBalanceEntry[];
   };
 }
 


### PR DESCRIPTION
## Summary

- **Extract `ProfitLossBalanceEntry` interface** from the inline array object type in `ProfitLossBreakdownSection`, improving readability and enabling reuse elsewhere.

Addresses the medium-severity review finding from Gemini Code Assist on PR #27 (line 121 of `src/tools/report.ts`).

Closes #30

### Verification

- `npm run build` — passes
- `npm run lint` — passes
- No runtime behaviour changes — interfaces only affect compile-time type checking