### PR TITLE
fix: remove overly broad VAT error matching in report handler

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -252,8 +252,7 @@ export async function handleReportTool(
           if (
             error instanceof QuickFileApiError &&
             (error.message.includes("not VAT registered") ||
-              error.message.includes("MTD not configured") ||
-              error.message.includes("VAT"))
+              error.message.includes("MTD not configured"))
           ) {
             return successResult({
               count: 0,


### PR DESCRIPTION
## Summary

- Removes the overly broad `error.message.includes("VAT")` condition from the VAT obligations catch block in `src/tools/report.ts`
- Keeps only the two specific, known configuration error patterns: `"not VAT registered"` and `"MTD not configured"`
- Prevents legitimate VAT-related errors (e.g., "VAT service unavailable") from being silently swallowed and presented as success

## Context

Addresses medium-severity review feedback from Gemini on PR #26 — the broad `"VAT"` substring match could mask real API failures, misleading users into thinking the request succeeded when it actually failed.

## Verification

- Build: `npm run build` -- clean
- Typecheck: `npm run typecheck` -- clean
- Lint: `npm run lint` -- 0 errors, 0 warnings
- Tests: `npm test` -- 201 passed, 0 failed

Closes #31