### PR TITLE
fix: remove overly broad VAT error catch that could swallow legitimate failures

### DIFF
--- a/src/tools/report.ts
+++ b/src/tools/report.ts
@@ -252,8 +252,7 @@ export async function handleReportTool(
           if (
             error instanceof QuickFileApiError &&
             (error.message.includes("not VAT registered") ||
-              error.message.includes("MTD not configured") ||
-              error.message.includes("VAT"))
+              error.message.includes("MTD not configured"))
           ) {
             return successResult({
               count: 0,


### PR DESCRIPTION
## Summary

- Removes the catch-all `error.message.includes("VAT")` condition from the VAT obligations error handler that could silently swallow legitimate API errors (e.g. "VAT service unavailable") and present them as successful empty results
- Keeps only the two specific conditions (`"not VAT registered"`, `"MTD not configured"`) that indicate a known account configuration issue

## Context

Addresses review feedback from Gemini Code Assist on PR #26 (captured in issue #31). The broad `"VAT"` substring match was added as a safety net but is too permissive — it masks errors that should propagate to the user.

Closes #31