### PR TITLE
docs: clarify tool count correction direction in v1.0.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- **README tool count** (retroactive): Acknowledged correction from 37 to actual count, applied in PR #8 between v1.0.1 and v1.0.2 releases
+- **README tool count** (retroactive): Acknowledged correction of tool count from 40+ to 37, applied in PR #8 between v1.0.1 and v1.0.2 releases
 
 ## [1.0.1] - 2025-12-01
 


### PR DESCRIPTION
## Summary

- Fixes confusing phrasing in CHANGELOG.md line 28: "correction from 37 to actual count" → "correction of tool count from 40+ to 37"
- The original README claimed 40+ tools; PR #8 corrected this to 37. The previous wording reversed the direction.

## Context

Addresses [Gemini Code Assist review feedback](https://github.com/marcusquinn/quickfile-mcp/pull/28#discussion_r2897363260) from PR #28, tracked as issue #29.

Closes #29