### PR TITLE
chore: add security baseline — pin Actions to SHA, add SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "npm"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately:
+
+**Email:** aidevops@marcusquinn.com
+
+**Please include:**
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes (optional)
+
+**Response timeline:**
+
+- Acknowledgment within 48 hours
+- Initial assessment within 7 days
+- Fix timeline communicated based on severity
+
+**Please do not:**
+
+- Open public issues for security vulnerabilities
+- Exploit vulnerabilities beyond proof-of-concept
+
+We appreciate responsible disclosure and will credit reporters in release notes
+(unless you prefer to remain anonymous).


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` and `actions/setup-node` to full SHA hashes in `ci.yml` and `release.yml` (`softprops/action-gh-release` was already pinned)
- Add `SECURITY.md` with vulnerability reporting instructions
- Enable branch protection on `main` requiring 1 PR review (applied via GitHub API, not a file change)

## Details

**SHA pinning** prevents supply-chain attacks where a compromised tag could inject malicious code into CI. Each action is pinned to its current commit SHA with a version comment for readability:

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |
| `softprops/action-gh-release` | `5be0e66d93ac7ed76da52eca8bb058f665c3a5fe` | v2.4.2 (already pinned) |

**Branch protection** now requires at least 1 approving review before merging to `main`, with stale review dismissal enabled. Admin enforcement is off so the repo owner can bypass in emergencies.

Closes #39