### PR TITLE
docs: specify 1.x version branch in SECURITY.md supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| Latest  | :white_check_mark: |
+| `1.x`   | :white_check_mark: |
 | < 1.0   | :x:                |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## Summary

- Replace ambiguous "Latest" with explicit `1.x` major version branch in the SECURITY.md supported versions table, providing a clearer and more stable support policy for users.

**Source:** PR #41 review feedback (Gemini Code Assist, medium severity)

Closes #42