### PR TITLE
Correct the Bank_CreateTransaction wire schema & surface real API errors

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -148,8 +148,22 @@ export class QuickFileApiClient {
       }
 
       if (!response.ok) {
+        let detailMessage = `HTTP ${response.status}: ${response.statusText}`;
+        try {
+          const errorBody = (await response.json()) as {
+            Errors?: { Error?: string | string[] };
+          };
+          const qfErrors = errorBody?.Errors?.Error;
+          if (Array.isArray(qfErrors) && qfErrors.length > 0) {
+            detailMessage = qfErrors.join("; ");
+          } else if (typeof qfErrors === "string") {
+            detailMessage = qfErrors;
+          }
+        } catch {
+          // Body wasn't JSON or didn't match expected shape — keep HTTP status fallback
+        }
         throw new QuickFileApiError(
-          `HTTP ${response.status}: ${response.statusText}`,
+          detailMessage,
           response.status.toString(),
         );
       }

--- a/src/tools/bank.ts
+++ b/src/tools/bank.ts
@@ -8,7 +8,7 @@ import { getApiClient } from "../api/client.js";
 import type {
   BankAccount,
   BankTransaction,
-  BankTransactionCreateParams,
+  BankTransactionWireItem,
   BankAccountType,
 } from "../types/quickfile.js";
 import {
@@ -227,7 +227,8 @@ interface BankAccountCreateResponse {
 }
 
 interface BankTransactionCreateResponse {
-  TransactionID: number;
+  InsertCount: number;
+  FailCount: number;
 }
 
 // =============================================================================
@@ -369,24 +370,31 @@ export async function handleBankTool(
       }
 
       case "quickfile_bank_create_transaction": {
-        const txnParams: BankTransactionCreateParams = {
-          NominalCode: args.nominalCode as string,
-          TransactionDate: args.transactionDate as string,
-          Amount: args.amount as number,
-          TransactionType: args.transactionType as "MONEY_IN" | "MONEY_OUT",
+        const direction = args.transactionType as "MONEY_IN" | "MONEY_OUT";
+        const magnitude = args.amount as number;
+        const signedAmount = direction === "MONEY_OUT" ? -Math.abs(magnitude) : Math.abs(magnitude);
+        const wireItem: BankTransactionWireItem = {
+          BankNominalCode: Number(args.nominalCode),
+          Date: args.transactionDate as string,
+          Amount: signedAmount,
           Reference: args.reference as string | undefined,
-          PayeePayer: args.payeePayer as string | undefined,
           Notes: args.notes as string | undefined,
         };
-        const cleaned = cleanParams(txnParams);
+        const cleaned = cleanParams(wireItem) as BankTransactionWireItem;
         const response = await apiClient.request<
-          { TransactionData: typeof cleaned },
+          { Transaction: BankTransactionWireItem[] },
           BankTransactionCreateResponse
-        >("Bank_CreateTransaction", { TransactionData: cleaned });
+        >("Bank_CreateTransaction", { Transaction: [cleaned] });
+        if (response.FailCount > 0 || response.InsertCount < 1) {
+          return errorResult(
+            `Bank transaction not created: InsertCount=${response.InsertCount}, FailCount=${response.FailCount}`,
+          );
+        }
         return successResult({
           success: true,
-          transactionId: response.TransactionID,
-          message: `Bank transaction created with ID ${response.TransactionID}`,
+          insertCount: response.InsertCount,
+          failCount: response.FailCount,
+          message: `Bank transaction created (InsertCount=${response.InsertCount})`,
         });
       }
 

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -327,6 +327,14 @@ export interface BankTransactionCreateParams {
   Notes?: string;
 }
 
+export interface BankTransactionWireItem {
+  BankNominalCode: number;
+  Date: string;
+  Amount: number;
+  Reference?: string;
+  Notes?: string;
+}
+
 // =============================================================================
 // Report Types
 // =============================================================================


### PR DESCRIPTION
I've discovered two bugs in the write path to QuickFile's `Bank_CreateTransaction` endpoint -  I hit them while using the MCP from a downstream project and wanted to flag them back upstream.

## 1. Wrong request body schema

The tool was sending

    Body: { TransactionData: { ... } }    // single object

but the QuickFile XSD expects

    Body: { Transaction: [{ ... }] }      // array
(the endpoint supports batch creation as it takes an array)

The inner field names/types also differ:

| Old (tool wire body)                   | New (QuickFile XSD)                     |
|----------------------------------------|------------------------------------------|
| `NominalCode: string`                  | `BankNominalCode: number`                |
| `TransactionDate: string`              | `Date: string`                           |
| `TransactionType: 'MONEY_IN'\|'MONEY_OUT'` | *(not a field — sign of `Amount`)*    |
| `Amount: number` (always positive)     | `Amount: number` (negative = money-out)  |
| `PayeePayer: string?`                  | *(not in the XSD for this endpoint)*     |

Every call to `quickfile_bank_create_transaction` was failing with an XSD validation error that got masked as a generic `HTTP 400: Bad Request` (see fix [2] below).

The **tool-facing** parameter schema (`nominalCode`, `transactionDate`, `transactionType`, `amount`, ...) is unchanged for backwards compatibility. Only the internal translation to the wire body was wrong. `transactionType` is now translated to a signed `Amount` before hitting the API, and `payeePayer` is silently dropped (it's not in the XSD — could be removed from the tool schema in a follow-up).

The response shape also differs from what the old code assumed. The batch endpoint returns `{ InsertCount, FailCount }`, not `{ TransactionID }`, so the response type and success message have been updated. A guard returns `isError: true` when `FailCount > 0` or `InsertCount < 1`.

## 2. Error masking in the API client

`client.ts` threw `HTTP {status}: {statusText}` on any non-2xx response without parsing the JSON body. QuickFile returns human-readable errors inside 4xx bodies in the shape

    { "Errors": { "Error": [ "<message>", ... ] } }

— XSD validation messages, permission-manifest failures, auth errors, etc. — and none of it was reaching callers. Every failure looked identical, making the MCP near-impossible to debug from the outside. I tracked down bug [1] by dropping to direct curl.

The client now parses the body before throwing. If the expected shape is present, the detail string is used; otherwise the HTTP status line is kept as a fallback so malformed error bodies don't break the throw path.

The existing `data.Errors` check on 2xx responses is unchanged.

## Verification

Tested end-to-end against the live QuickFile API by creating and deleting a real 1p transaction against nominal 1230 (Petty Cash). Response was `{ InsertCount: 1, FailCount: 0 }`, tool returned `success: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling throughout the API client to provide more descriptive error messages when API requests fail. Now extracts and displays detailed error information when available, with fallback to standard HTTP status messages.
* **Improvements**
  * Updated bank transaction creation workflow to align with current API specifications and improve how transaction processing results are handled by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->