### PR TITLE
Fix purchase create/search wire schemas + add document upload tools

### DIFF
--- a/src/tools/document.ts
+++ b/src/tools/document.ts
@@ -1,0 +1,200 @@
+/**
+ * QuickFile Document Tools
+ * Document upload and receipt attachment operations
+ */
+
+import { readFileSync } from "node:fs";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { QuickFileApiClient } from "../api/client.js";
+import type {
+  DocumentUploadParams,
+  DocumentUploadResponse,
+} from "../types/quickfile.js";
+import { handleToolError, successResult, type ToolResult } from "./utils.js";
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+const fileSourceProperties = {
+  fileData: {
+    type: "string" as const,
+    description:
+      "Base64-encoded file content (mutually exclusive with filePath)",
+  },
+  filePath: {
+    type: "string" as const,
+    description:
+      "Absolute local file path — the server reads and base64-encodes the " +
+      "file (mutually exclusive with fileData)",
+  },
+};
+
+export const documentTools: Tool[] = [
+  {
+    name: "quickfile_document_upload_receipt",
+    description:
+      "Upload a receipt file (PDF, image) and attach it to an existing " +
+      "purchase invoice. Use this after creating a purchase to attach the " +
+      "original invoice/receipt. Provide either fileData (base64) or " +
+      "filePath (absolute path) — exactly one of the two.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        purchaseId: {
+          type: "number",
+          description: "The purchase ID to attach the receipt to",
+        },
+        fileName: {
+          type: "string",
+          description:
+            'File name including extension (e.g., "invoice.pdf", "receipt.png")',
+        },
+        ...fileSourceProperties,
+      },
+      required: ["purchaseId", "fileName"],
+    },
+  },
+  {
+    name: "quickfile_document_upload_sales_attachment",
+    description:
+      "Upload a document and attach it to an existing sales invoice. " +
+      "Provide either fileData (base64) or filePath (absolute path) — " +
+      "exactly one of the two.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        invoiceId: {
+          type: "number",
+          description: "The invoice ID to attach the document to",
+        },
+        fileName: {
+          type: "string",
+          description: 'File name including extension (e.g., "contract.pdf")',
+        },
+        ...fileSourceProperties,
+      },
+      required: ["invoiceId", "fileName"],
+    },
+  },
+];
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Resolve the file content to a base64 string. Callers may supply either
+ * `fileData` (already base64-encoded) or `filePath` (absolute local path —
+ * read and encoded here). Exactly one of the two must be provided.
+ */
+function resolveFileData(args: Record<string, unknown>): string {
+  const fileData = args.fileData as string | undefined;
+  const filePath = args.filePath as string | undefined;
+
+  if (fileData && filePath) {
+    throw new Error("Provide either fileData or filePath, not both");
+  }
+  if (fileData) {
+    return fileData;
+  }
+  if (filePath) {
+    return readFileSync(filePath).toString("base64");
+  }
+  throw new Error("Either fileData or filePath must be provided");
+}
+
+// =============================================================================
+// Tool Handlers
+// =============================================================================
+
+export async function handleDocumentTool(
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  // Dedicated client with a longer timeout for file uploads — don't clobber
+  // the process-wide singleton.
+  const apiClient = new QuickFileApiClient({ timeout: 60000 });
+
+  try {
+    switch (toolName) {
+      case "quickfile_document_upload_receipt": {
+        const purchaseId = args.purchaseId as number;
+        const fileName = args.fileName as string;
+        const fileData = resolveFileData(args);
+        const captureDateTime = new Date().toISOString();
+
+        const response = await apiClient.request<
+          DocumentUploadParams,
+          DocumentUploadResponse
+        >("Document_Upload", {
+          DocumentDetails: {
+            FileName: fileName,
+            EmbeddedFileBinaryObject: fileData,
+            Type: {
+              Receipt: {
+                PurchaseId: purchaseId,
+                CaptureDateTime: captureDateTime,
+              },
+            },
+          },
+        });
+
+        const firstDoc = response.DocumentData?.Data?.[0];
+
+        return successResult({
+          success: true,
+          purchaseId,
+          documentId: firstDoc?.Id,
+          path: firstDoc?.Path,
+          uploadTimestamp: response.UploadTimeStamp,
+          message: `Receipt "${fileName}" attached to purchase #${purchaseId}`,
+        });
+      }
+
+      case "quickfile_document_upload_sales_attachment": {
+        const invoiceId = args.invoiceId as number;
+        const fileName = args.fileName as string;
+        const fileData = resolveFileData(args);
+        const captureDateTime = new Date().toISOString();
+
+        const response = await apiClient.request<
+          DocumentUploadParams,
+          DocumentUploadResponse
+        >("Document_Upload", {
+          DocumentDetails: {
+            FileName: fileName,
+            EmbeddedFileBinaryObject: fileData,
+            Type: {
+              SalesAttachment: {
+                InvoiceId: invoiceId,
+                CaptureDateTime: captureDateTime,
+              },
+            },
+          },
+        });
+
+        const firstDoc = response.DocumentData?.Data?.[0];
+
+        return successResult({
+          success: true,
+          invoiceId,
+          documentId: firstDoc?.Id,
+          path: firstDoc?.Path,
+          uploadTimestamp: response.UploadTimeStamp,
+          message: `Document "${fileName}" attached to invoice #${invoiceId}`,
+        });
+      }
+
+      default:
+        return {
+          content: [
+            { type: "text", text: `Unknown document tool: ${toolName}` },
+          ],
+          isError: true,
+        };
+    }
+  } catch (error) {
+    return handleToolError(error);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { purchaseTools, handlePurchaseTool } from "./purchase.js";
 import { supplierTools, handleSupplierTool } from "./supplier.js";
 import { bankTools, handleBankTool } from "./bank.js";
 import { reportTools, handleReportTool } from "./report.js";
+import { documentTools, handleDocumentTool } from "./document.js";
 
 // Import ToolResult for local use, then re-export
 import type { ToolResult } from "./utils.js";
@@ -36,6 +37,7 @@ export const allTools: Tool[] = [
   ...supplierTools,
   ...bankTools,
   ...reportTools,
+  ...documentTools,
 ];
 
 /**
@@ -83,12 +85,17 @@ export async function handleToolCall(
     return handleReportTool(toolName, args);
   }
 
+  // Document tools
+  if (toolName.startsWith("quickfile_document_")) {
+    return handleDocumentTool(toolName, args);
+  }
+
   // Unknown tool
   return {
     content: [
       {
         type: "text",
-        text: `Unknown tool: ${toolName}. Available prefixes: quickfile_system_, quickfile_client_, quickfile_invoice_, quickfile_estimate_, quickfile_purchase_, quickfile_supplier_, quickfile_bank_, quickfile_report_`,
+        text: `Unknown tool: ${toolName}. Available prefixes: quickfile_system_, quickfile_client_, quickfile_invoice_, quickfile_estimate_, quickfile_purchase_, quickfile_supplier_, quickfile_bank_, quickfile_report_, quickfile_document_`,
       },
     ],
     isError: true,
@@ -111,4 +118,6 @@ export {
   handleBankTool,
   reportTools,
   handleReportTool,
+  documentTools,
+  handleDocumentTool,
 };

--- a/src/tools/purchase.ts
+++ b/src/tools/purchase.ts
@@ -162,31 +162,35 @@ interface PurchaseCreateResponse {
 // Helper Functions (extracted to reduce duplication)
 // =============================================================================
 
-/** Field mapping from tool args to QuickFile Purchase_Search API parameters */
-const PURCHASE_SEARCH_FIELD_MAP: ReadonlyArray<[string, string]> = [
-  ["supplierId", "SupplierID"],
-  ["dateFrom", "DateFrom"],
-  ["dateTo", "DateTo"],
-  ["status", "Status"],
-  ["searchKeyword", "SearchKeyword"],
-];
-
 function buildPurchaseSearchParams(
   args: Record<string, unknown>,
 ): Record<string, unknown> {
+  // The Purchase_Search XSD is an xs:sequence — the server enforces element
+  // order. Build in the schema's required order: paging → ordering → filters.
+  // Also note that SupplierID must be nested under SupplierDetails (not a bare
+  // field) and date filters use ReceiptDate prefix on this endpoint.
   const searchParams: Record<string, unknown> = {
     ReturnCount: (args.returnCount as number) ?? 25,
     Offset: (args.offset as number) ?? 0,
+    OrderResultsBy: (args.orderBy as string) ?? "ReceiptDate",
+    OrderDirection: (args.orderDirection as string) ?? "DESC",
   };
 
-  for (const [argKey, apiKey] of PURCHASE_SEARCH_FIELD_MAP) {
-    if (args[argKey] !== undefined) {
-      searchParams[apiKey] = args[argKey];
-    }
+  if (args.supplierId !== undefined) {
+    searchParams.SupplierDetails = { SupplierID: args.supplierId };
   }
-
-  searchParams.OrderResultsBy = (args.orderBy as string) ?? "ReceiptDate";
-  searchParams.OrderDirection = (args.orderDirection as string) ?? "DESC";
+  if (args.dateFrom !== undefined) {
+    searchParams.ReceiptDateFrom = args.dateFrom;
+  }
+  if (args.dateTo !== undefined) {
+    searchParams.ReceiptDateTo = args.dateTo;
+  }
+  if (args.status !== undefined) {
+    searchParams.Status = args.status;
+  }
+  if (args.searchKeyword !== undefined) {
+    searchParams.SearchKeyword = args.searchKeyword;
+  }
 
   return searchParams;
 }

--- a/src/tools/purchase.ts
+++ b/src/tools/purchase.ts
@@ -8,14 +8,13 @@ import { getApiClient } from "../api/client.js";
 import type {
   Purchase,
   PurchaseCreateParams,
-  PurchaseLine,
+  PurchaseItemLine,
 } from "../types/quickfile.js";
 import {
   handleToolError,
   successResult,
   errorResult,
   cleanParams,
-  mapLineItems,
   dateRangeSearchProperties,
   lineItemSchemaProperties,
   type LineItemInput,
@@ -89,19 +88,16 @@ export const purchaseTools: Tool[] = [
         },
         issueDate: {
           type: "string",
-          description: "Invoice date (YYYY-MM-DD)",
-        },
-        dueDate: {
-          type: "string",
-          description: "Due date (YYYY-MM-DD)",
+          description: "Receipt date on the supplier's document (YYYY-MM-DD)",
         },
         supplierRef: {
           type: "string",
           description: "Supplier invoice reference number",
         },
-        notes: {
-          type: "string",
-          description: "Notes",
+        termDays: {
+          type: "number",
+          description: "Payment terms in days from the receipt date (default: 30)",
+          default: 30,
         },
         lines: {
           type: "array",
@@ -155,7 +151,7 @@ interface PurchaseGetResponse {
 
 interface PurchaseCreateResponse {
   PurchaseID: number;
-  PurchaseNumber: string;
+  PurchaseTotal?: number;
 }
 
 // =============================================================================
@@ -233,16 +229,33 @@ export async function handlePurchaseTool(
 
       case "quickfile_purchase_create": {
         const lineItems = args.lines as LineItemInput[];
-        const purchaseLines = mapLineItems<PurchaseLine>(lineItems);
 
+        // Purchase_Create's ItemLine schema differs from Invoice_Create's:
+        // it expects pre-calculated SubTotal and VatTotal fields rather than
+        // the raw UnitCost/Qty/Tax1 triple that mapLineItems produces. We
+        // therefore build the line items inline rather than using that helper.
+        const itemLines: PurchaseItemLine[] = lineItems.map((line) => {
+          const subTotal =
+            Math.round(line.unitCost * line.quantity * 100) / 100;
+          const vatRate = line.vatPercentage ?? 0;
+          const vatTotal = Math.round(subTotal * vatRate) / 100;
+          return {
+            ItemDescription: line.description,
+            ItemNominalCode: line.nominalCode ?? "",
+            SubTotal: subTotal,
+            VatRate: vatRate,
+            VatTotal: vatTotal,
+          };
+        });
+
+        // Element order matches the XSD xs:sequence for PurchaseData.
         const createParams: PurchaseCreateParams = {
           SupplierID: args.supplierId as number,
           Currency: (args.currency as string) ?? "GBP",
-          IssueDate: args.issueDate as string | undefined,
-          DueDate: args.dueDate as string | undefined,
-          SupplierRef: args.supplierRef as string | undefined,
-          Notes: args.notes as string | undefined,
-          PurchaseLines: purchaseLines,
+          ReceiptDate: args.issueDate as string | undefined,
+          SupplierReference: args.supplierRef as string | undefined,
+          TermDays: (args.termDays as number) ?? 30,
+          InvoiceLines: { ItemLine: itemLines },
         };
 
         const cleaned = cleanParams(createParams);
@@ -255,8 +268,8 @@ export async function handlePurchaseTool(
         return successResult({
           success: true,
           purchaseId: response.PurchaseID,
-          purchaseNumber: response.PurchaseNumber,
-          message: `Purchase #${response.PurchaseNumber} created successfully`,
+          purchaseTotal: response.PurchaseTotal,
+          message: `Purchase ${response.PurchaseID} created successfully`,
         });
       }
 

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -459,3 +459,53 @@ export interface CreateNoteParams {
   EntityID: number;
   NoteText: string;
 }
+
+// =============================================================================
+// Document Types
+// =============================================================================
+
+/** Receipt attachment — linked to a purchase */
+export interface DocumentTypeReceipt {
+  Receipt: {
+    PurchaseId: number;
+    CaptureDateTime: string;
+  };
+}
+
+/** Sales attachment — linked to an invoice */
+export interface DocumentTypeSalesAttachment {
+  SalesAttachment: {
+    InvoiceId: number;
+    CaptureDateTime: string;
+  };
+}
+
+/** General attachment — not linked to a specific entity */
+export interface DocumentTypeGeneral {
+  General: {
+    CaptureDateTime: string;
+  };
+}
+
+export type DocumentType =
+  | DocumentTypeReceipt
+  | DocumentTypeSalesAttachment
+  | DocumentTypeGeneral;
+
+export interface DocumentUploadParams {
+  DocumentDetails: {
+    FileName: string;
+    EmbeddedFileBinaryObject: string; // base64-encoded file data
+    Type: DocumentType;
+  };
+}
+
+export interface DocumentUploadResponse {
+  UploadTimeStamp: string;
+  DocumentData: {
+    Data: Array<{
+      Id: number;
+      Path: string;
+    }>;
+  };
+}

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -219,6 +219,19 @@ export interface PurchaseLine {
   LineTotal?: number;
 }
 
+/**
+ * Line-item shape accepted by Purchase_Create (distinct from the PurchaseLine
+ * shape returned by Purchase_Get). The wire schema expects pre-calculated
+ * SubTotal and VatTotal here, not raw UnitCost/Qty/Tax1.
+ */
+export interface PurchaseItemLine {
+  ItemDescription: string;
+  ItemNominalCode: string;
+  SubTotal: number;
+  VatRate: number;
+  VatTotal: number;
+}
+
 export interface PurchaseSearchParams {
   SupplierID?: number;
   DateFrom?: string;
@@ -234,11 +247,10 @@ export interface PurchaseSearchParams {
 export interface PurchaseCreateParams {
   SupplierID: number;
   Currency?: string;
-  IssueDate?: string;
-  DueDate?: string;
-  PurchaseLines: PurchaseLine[];
-  Notes?: string;
-  SupplierRef?: string;
+  ReceiptDate?: string;
+  SupplierReference?: string;
+  TermDays?: number;
+  InvoiceLines: { ItemLine: PurchaseItemLine[] };
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Three independent changes to the Purchase and Document tool families,
bundled into one PR because commits 1 and 2 share the XSD-ordering
discovery and all three touch `src/types/quickfile.ts`.

| Commit | What |
|---|---|
| 01cade2 | Fix purchase search — three compounding bugs in request formatting |
| e184a95 | Fix purchase creation — multiple wire-schema mismatches |
| 024f794 | Add `Document_Upload` tools for attaching receipts and sales documents |

Full commit messages explain each bug in detail. Short version:

- **`Purchase_Search` was returning 400 on any call with a filter.** Three compounding problems: `SupplierID` needs nesting under `SupplierDetails`, date filters use `ReceiptDateFrom`/`ReceiptDateTo` not `DateFrom`/`DateTo`, and `SearchParameters` is an `xs:sequence` so ordering matters.
- **`Purchase_Create` was returning 400 on every call.** Five distinct wire-schema mismatches plus a response-field typo that made the success message say `"Purchase #undefined created successfully"` the first time it was reached. The ItemLine shape on this endpoint is genuinely different from `Invoice_Create`'s InvoiceLine shape (separate XSDs), so `mapLineItems` can't be shared between them — a short callsite comment warns future maintainers.
- **New `Document_Upload` tools** for attaching receipts to purchases and documents to sales invoices. Both tools accept either `fileData` (base64) or `filePath` (absolute path, server reads and encodes) — the `filePath` path is there so LLM-driven pipelines can attach multi-MB PDFs without pushing the entire base64 string through model context.

## Breaking changes

The `quickfile_purchase_create` tool drops two input parameters that were never supported by QuickFile's `Purchase_Create` endpoint:

- `dueDate` (not a valid element on `PurchaseData`) → replaced by `termDays` (integer, default 30).
- `notes` (not a valid element on `PurchaseData`) → dropped. The nearest equivalent, `InvoiceDescription`, has its own data-type constraints that I didn't want to take on without testing.

Every other public parameter name on every tool is unchanged.

## Out of scope for this PR

Integration test at `tests/integration/api.test.ts:149` only exercises the minimal `Purchase_Search` path (no filters), which is why it didn't catch the schema bugs. I've left it alone — adding a filtered-search test would require a fixture purchase, which feels like its own change.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 251/251 unit tests pass
- [x] `npm run build` — clean
- [x] `Purchase_Search` — exercised against live QuickFile API via the rebuilt handler; filtered and unfiltered queries both return expected records.
- [x] `Purchase_Create` — exercised against live QuickFile API via the rebuilt handler; creates a £0.01 test purchase against a real supplier, returns `{ PurchaseID, PurchaseTotal }`, success message is clean.
- [x] `Document_Upload` — underlying wire format verified via an earlier ad-hoc use of this tool to attach a real PDF to an existing purchase; handler smoke-tested (tool registration, either-or validation, mutually-exclusive validation).

## Related

Sibling PR to #46 (`Correct the Bank_CreateTransaction wire schema & surface real API errors`). No overlap in files, no ordering dependency between the two — feel free to merge in either order.

## AI assistance disclosure

This PR was drafted with Claude (Anthropic's Claude Opus 4.7 model). I reviewed each commit, approved each message, and ran the live-API verification myself before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added document upload capabilities for receipts and sales attachments, supporting both file-based uploads and direct data submission approaches.

* **Improvements**
  * Improved purchase creation workflow with restructured field requirements: removed due date and notes fields, introduced configurable term days (30-day default), and reorganized the purchase line item structure for better data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->