### PR TITLE
fix: address Bank_CreateTransaction review bot feedback (PR #46 followup)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -154,18 +154,21 @@ export class QuickFileApiClient {
             Errors?: { Error?: string | string[] };
           };
           const qfErrors = errorBody?.Errors?.Error;
-          if (Array.isArray(qfErrors) && qfErrors.length > 0) {
-            detailMessage = qfErrors.join("; ");
-          } else if (typeof qfErrors === "string") {
-            detailMessage = qfErrors;
+          const messages = Array.isArray(qfErrors) ? qfErrors : [qfErrors];
+          const combined = messages
+            .filter((m): m is string => typeof m === "string" && m.trim() !== "")
+            .join("; ");
+          if (combined) {
+            detailMessage = combined;
           }
         } catch {
           // Body wasn't JSON or didn't match expected shape — keep HTTP status fallback
         }
-        throw new QuickFileApiError(
-          detailMessage,
-          response.status.toString(),
-        );
+        const errorCode =
+          response.status === 401 || response.status === 403
+            ? "INVALID_AUTH"
+            : response.status.toString();
+        throw new QuickFileApiError(detailMessage, errorCode);
       }
 
       const data = (await response.json()) as QuickFileResponse<TResponse>;

--- a/src/tools/bank.ts
+++ b/src/tools/bank.ts
@@ -185,10 +185,6 @@ export const bankTools: Tool[] = [
           type: "string",
           description: "Transaction reference",
         },
-        payeePayer: {
-          type: "string",
-          description: "Name of payee or payer",
-        },
         notes: {
           type: "string",
           description: "Additional notes",
@@ -370,11 +366,18 @@ export async function handleBankTool(
       }
 
       case "quickfile_bank_create_transaction": {
-        const direction = args.transactionType as "MONEY_IN" | "MONEY_OUT";
+        const bankNominalCode = Number.parseInt(args.nominalCode as string, 10);
         const magnitude = args.amount as number;
-        const signedAmount = direction === "MONEY_OUT" ? -Math.abs(magnitude) : Math.abs(magnitude);
+        if (!Number.isInteger(bankNominalCode)) {
+          return errorResult("nominalCode must be a numeric bank account code");
+        }
+        if (!Number.isFinite(magnitude) || magnitude <= 0) {
+          return errorResult("amount must be a positive number");
+        }
+        const direction = args.transactionType as "MONEY_IN" | "MONEY_OUT";
+        const signedAmount = direction === "MONEY_OUT" ? -magnitude : magnitude;
         const wireItem: BankTransactionWireItem = {
-          BankNominalCode: Number(args.nominalCode),
+          BankNominalCode: bankNominalCode,
           Date: args.transactionDate as string,
           Amount: signedAmount,
           Reference: args.reference as string | undefined,

--- a/src/tools/document.ts
+++ b/src/tools/document.ts
@@ -3,7 +3,7 @@
  * Document upload and receipt attachment operations
  */
 
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { QuickFileApiClient } from "../api/client.js";
 import type {
@@ -88,7 +88,9 @@ export const documentTools: Tool[] = [
  * `fileData` (already base64-encoded) or `filePath` (absolute local path —
  * read and encoded here). Exactly one of the two must be provided.
  */
-function resolveFileData(args: Record<string, unknown>): string {
+async function resolveFileData(
+  args: Record<string, unknown>,
+): Promise<string> {
   const fileData = args.fileData as string | undefined;
   const filePath = args.filePath as string | undefined;
 
@@ -99,7 +101,8 @@ function resolveFileData(args: Record<string, unknown>): string {
     return fileData;
   }
   if (filePath) {
-    return readFileSync(filePath).toString("base64");
+    const buffer = await readFile(filePath);
+    return buffer.toString("base64");
   }
   throw new Error("Either fileData or filePath must be provided");
 }
@@ -121,7 +124,7 @@ export async function handleDocumentTool(
       case "quickfile_document_upload_receipt": {
         const purchaseId = args.purchaseId as number;
         const fileName = args.fileName as string;
-        const fileData = resolveFileData(args);
+        const fileData = await resolveFileData(args);
         const captureDateTime = new Date().toISOString();
 
         const response = await apiClient.request<
@@ -155,7 +158,7 @@ export async function handleDocumentTool(
       case "quickfile_document_upload_sales_attachment": {
         const invoiceId = args.invoiceId as number;
         const fileName = args.fileName as string;
-        const fileData = resolveFileData(args);
+        const fileData = await resolveFileData(args);
         const captureDateTime = new Date().toISOString();
 
         const response = await apiClient.request<

--- a/src/tools/purchase.ts
+++ b/src/tools/purchase.ts
@@ -237,7 +237,7 @@ export async function handlePurchaseTool(
         const itemLines: PurchaseItemLine[] = lineItems.map((line) => {
           const subTotal =
             Math.round(line.unitCost * line.quantity * 100) / 100;
-          const vatRate = line.vatPercentage ?? 0;
+          const vatRate = line.vatPercentage ?? 20; // default 20% matches invoice_create and the schema default
           const vatTotal = Math.round(subTotal * vatRate) / 100;
           return {
             ItemDescription: line.description,

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -218,6 +218,52 @@ describe("QuickFileApiClient", () => {
       );
     });
 
+    it("should normalize 401 to INVALID_AUTH error code", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: () => Promise.resolve({}),
+      });
+
+      const client = await getClient();
+
+      await expect(client.request("Client_Search", {})).rejects.toMatchObject({
+        code: "INVALID_AUTH",
+      });
+    });
+
+    it("should normalize 403 to INVALID_AUTH error code", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: () => Promise.resolve({}),
+      });
+
+      const client = await getClient();
+
+      await expect(client.request("Client_Search", {})).rejects.toMatchObject({
+        code: "INVALID_AUTH",
+      });
+    });
+
+    it("should filter empty strings from qfErrors array", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        json: () =>
+          Promise.resolve({ Errors: { Error: ["", "Real error", "  "] } }),
+      });
+
+      const client = await getClient();
+
+      await expect(client.request("Client_Search", {})).rejects.toMatchObject({
+        message: "Real error",
+      });
+    });
+
     it("should throw on API error response", async () => {
       const mockResponse = {
         Errors: [


### PR DESCRIPTION
## Summary

Addresses all unresolved review bot feedback from PR #46 on `src/api/client.ts` and `src/tools/bank.ts`, plus two additional correctness fixes surfaced during the triage pass.

### Changes

**`src/api/client.ts`** (review feedback from PR #46)
- Filter empty/whitespace-only strings from `qfErrors` array before joining — prevents blank error messages when the API returns an array of empty strings (Gemini, `client.ts:161`)
- Normalize HTTP 401 and 403 responses to `INVALID_AUTH` error code per coding guidelines instead of the raw status string (CodeRabbit major, `client.ts:167`)

**`src/tools/bank.ts`** (review feedback from PR #46)
- Use `Number.parseInt(nominalCode, 10)` instead of `Number()` — prevents silent float coercion and avoids `0` on empty string (Gemini, `bank.ts:377`)
- Validate `nominalCode` (must be a valid integer) and `amount` (must be a finite positive number) before building the wire item, returning a structured `errorResult` instead of sending NaN/invalid data (CodeRabbit, `bank.ts:379`)
- Remove `Math.abs` from `signedAmount` — amount is now validated positive, so the silent rewrite is unnecessary (CodeRabbit, `bank.ts:379`)
- Remove `payeePayer` from the `quickfile_bank_create_transaction` inputSchema — the field was silently dropped when building the wire item and is unsupported by the endpoint (Gemini, `bank.ts:382`)

**`src/tools/document.ts`** (correctness fix)
- Replace synchronous `readFileSync` with async `readFile` from `node:fs/promises` — removes a blocking syscall in an async handler and fixes the TypeScript error from PR #48

**`src/tools/purchase.ts`** (correctness fix)
- Default `vatPercentage` to `20%` instead of `0%` — matches the invoice_create behaviour and the schema default

**`tests/unit/client.test.ts`**
- Added 3 new test cases: 401→INVALID_AUTH, 403→INVALID_AUTH, and empty-string filtering in qfErrors array (254 tests, all pass)

Resolves #56