### PR TITLE
t57: fix(bank): parseInt consistency + remove unused payeePayer from inputSchema

### DIFF
--- a/src/tools/bank.ts
+++ b/src/tools/bank.ts
@@ -185,10 +185,6 @@ export const bankTools: Tool[] = [
           type: "string",
           description: "Transaction reference",
         },
-        payeePayer: {
-          type: "string",
-          description: "Name of payee or payer",
-        },
         notes: {
           type: "string",
           description: "Additional notes",
@@ -374,7 +370,7 @@ export async function handleBankTool(
         const magnitude = args.amount as number;
         const signedAmount = direction === "MONEY_OUT" ? -Math.abs(magnitude) : Math.abs(magnitude);
         const wireItem: BankTransactionWireItem = {
-          BankNominalCode: Number(args.nominalCode),
+          BankNominalCode: Number.parseInt(args.nominalCode as string, 10),
           Date: args.transactionDate as string,
           Amount: signedAmount,
           Reference: args.reference as string | undefined,


### PR DESCRIPTION
## Summary

Two quality fixes to `src/tools/bank.ts` from Gemini review feedback on PR #46:

1. **`Number.parseInt` consistency** (`bank.ts:377`): Replace `Number(args.nominalCode)` with `Number.parseInt(args.nominalCode as string, 10)` in the `quickfile_bank_create_transaction` handler — matches the pattern already used in `buildBankSearchParams` (line 255) and avoids silent conversion of empty string to `0`.

2. **Remove unused `payeePayer` from `inputSchema`** (`bank.ts:188-191`): The field was declared in the tool schema but never passed to the `Bank_CreateTransaction` API payload. Leaving it misleads the AI model into thinking the API accepts it.

## Verification

- `npm run build` passes cleanly (TypeScript compilation, zero errors)
- No runtime behaviour changed — the arithmetic is identical for valid numeric inputs; only empty-string edge case is now handled correctly

Resolves #52


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 4,968 tokens on this as a headless worker.