### PR TITLE
t54: fix(purchase): restore 20% VAT default for purchase line items

### DIFF
--- a/src/tools/purchase.ts
+++ b/src/tools/purchase.ts
@@ -237,7 +237,7 @@ export async function handlePurchaseTool(
         const itemLines: PurchaseItemLine[] = lineItems.map((line) => {
           const subTotal =
             Math.round(line.unitCost * line.quantity * 100) / 100;
-          const vatRate = line.vatPercentage ?? 0;
+          const vatRate = line.vatPercentage ?? 20;
           const vatTotal = Math.round(subTotal * vatRate) / 100;
           return {
             ItemDescription: line.description,


### PR DESCRIPTION
## Summary

Restores the 20% VAT default for purchase line items, which was inadvertently changed to 0% in PR #48.

## What Changed

**`src/tools/purchase.ts:240`** — `const vatRate = line.vatPercentage ?? 0` → `?? 20`

## Why

PR #48 inlined the `ItemLine` construction (to match the Purchase_Create XSD schema) but used `?? 0` instead of `?? 20` as the VAT fallback. This silently changed the behaviour for any caller that omits `vatPercentage`:

- `mapLineItems` (used by `invoice_create`) defaults to `?? 20` — `utils.ts:200`
- `lineItemSchemaProperties.vatPercentage` documents `"VAT percentage (default: 20)"` with `default: 20` — `utils.ts:291-292`
- The prior Purchase_Create `mapLineItems` path also defaulted to 20%

Purchases created without explicit `vatPercentage` were posting with 0% VAT, understating reclaimable UK input VAT and producing incorrect VAT returns.

## Verification

- `npm run build` — passes cleanly (no TypeScript errors)
- The fix aligns all line-item VAT fallbacks to a consistent 20% default

Resolves #54


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 3m and 4,506 tokens on this as a headless worker.