### PR TITLE
t58: fix(client): robust error extraction and normalize 401/403 to INVALID_AUTH

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -154,18 +154,21 @@ export class QuickFileApiClient {
             Errors?: { Error?: string | string[] };
           };
           const qfErrors = errorBody?.Errors?.Error;
-          if (Array.isArray(qfErrors) && qfErrors.length > 0) {
-            detailMessage = qfErrors.join("; ");
-          } else if (typeof qfErrors === "string") {
-            detailMessage = qfErrors;
+          const messages = Array.isArray(qfErrors) ? qfErrors : [qfErrors];
+          const combined = messages
+            .filter((m): m is string => typeof m === "string" && m.trim() !== "")
+            .join("; ");
+          if (combined) {
+            detailMessage = combined;
           }
         } catch {
           // Body wasn't JSON or didn't match expected shape — keep HTTP status fallback
         }
-        throw new QuickFileApiError(
-          detailMessage,
-          response.status.toString(),
-        );
+        const errorCode =
+          response.status === 401 || response.status === 403
+            ? "INVALID_AUTH"
+            : response.status.toString();
+        throw new QuickFileApiError(detailMessage, errorCode);
       }
 
       const data = (await response.json()) as QuickFileResponse<TResponse>;


### PR DESCRIPTION
## Summary

Addresses two review findings from PR #46 on `src/api/client.ts`:

### Fix 1: Robust error message extraction (Gemini finding)

The previous array-path joined all items including empty strings, and the string-path accepted empty strings without filtering. This could result in an empty error message overwriting the HTTP status fallback.

**Before:**
```typescript
if (Array.isArray(qfErrors) && qfErrors.length > 0) {
  detailMessage = qfErrors.join("; ");
} else if (typeof qfErrors === "string") {
  detailMessage = qfErrors;
}
```

**After:**
```typescript
const messages = Array.isArray(qfErrors) ? qfErrors : [qfErrors];
const combined = messages
  .filter((m): m is string => typeof m === "string" && m.trim() !== "")
  .join("; ");
if (combined) {
  detailMessage = combined;
}
```

### Fix 2: Normalize 401/403 to INVALID_AUTH (CodeRabbit finding)

401 and 403 responses were throwing with raw numeric status codes (`"401"`, `"403"`) instead of the normalized `INVALID_AUTH` code specified in coding guidelines.

**Before:**
```typescript
throw new QuickFileApiError(detailMessage, response.status.toString());
```

**After:**
```typescript
const errorCode =
  response.status === 401 || response.status === 403
    ? "INVALID_AUTH"
    : response.status.toString();
throw new QuickFileApiError(detailMessage, errorCode);
```

## Verification

- `npm run build` — clean TypeScript compilation
- `npm test` — 251/251 tests pass

Resolves #51

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 6,888 tokens on this as a headless worker.