### PR TITLE
GH#70: Allow deleted purchase search status

### DIFF
--- a/src/tools/purchase.ts
+++ b/src/tools/purchase.ts
@@ -43,7 +43,7 @@ export const purchaseTools: Tool[] = [
         ...dateRangeSearchProperties,
         status: {
           type: "string",
-          enum: ["UNPAID", "PAID", "PART_PAID", "CANCELLED"],
+          enum: ["UNPAID", "PAID", "PART_PAID", "CANCELLED", "DELETED"],
           description: "Purchase status",
         },
         searchKeyword: {

--- a/tests/unit/purchase.test.ts
+++ b/tests/unit/purchase.test.ts
@@ -28,6 +28,22 @@ describe("Purchase tools", () => {
     });
   });
 
+  describe("quickfile_purchase_search", () => {
+    it("allows searching soft-deleted purchases by status", () => {
+      const tool = purchaseTools.find(
+        (candidate) => candidate.name === "quickfile_purchase_search",
+      );
+
+      expect(tool?.inputSchema).toMatchObject({
+        properties: {
+          status: {
+            enum: ["UNPAID", "PAID", "PART_PAID", "CANCELLED", "DELETED"],
+          },
+        },
+      });
+    });
+  });
+
   describe("quickfile_purchase_delete", () => {
     it("declares purchaseIds and deleteAssociatedPayments as sibling schema properties", () => {
       const tool = purchaseTools.find(


### PR DESCRIPTION
## Summary

Expose the DELETED status in the quickfile_purchase_search input schema so users can find soft-deleted purchases created by the Purchase_Delete flow.

## Files Changed

src/tools/purchase.ts,tests/unit/purchase.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- tests/unit/purchase.test.ts; npm run typecheck; npm run lint; npm run build; npm run secretlint

Resolves #70


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.42 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8m and 86,730 tokens on this as a headless worker.