### PR TITLE
GH#73: test: cover deleted purchase search status

### DIFF
--- a/tests/unit/purchase.test.ts
+++ b/tests/unit/purchase.test.ts
@@ -42,6 +42,28 @@ describe("Purchase tools", () => {
         },
       });
     });
+
+    it("passes DELETED status through to QuickFile search", async () => {
+      mockRequest.mockResolvedValueOnce({
+        RecordsetCount: 0,
+        ReturnCount: 0,
+        Record: [],
+      });
+
+      await handlePurchaseTool("quickfile_purchase_search", {
+        status: "DELETED",
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith("Purchase_Search", {
+        SearchParameters: {
+          ReturnCount: 25,
+          Offset: 0,
+          OrderResultsBy: "ReceiptDate",
+          OrderDirection: "DESC",
+          Status: "DELETED",
+        },
+      });
+    });
   });
 
   describe("quickfile_purchase_delete", () => {


### PR DESCRIPTION
## Summary

Added regression coverage proving quickfile_purchase_search forwards Status=DELETED inside the QuickFile SearchParameters payload, matching the schema enum that now exposes deleted purchases.

## Files Changed

tests/unit/purchase.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- --runTestsByPath tests/unit/purchase.test.ts; npm run typecheck

Resolves #73


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 7m and 58,234 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for purchase search functionality with additional assertion validation.

---

**Note:** This release includes no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->