### PR TITLE
GH#72: test: strengthen deleted purchase search coverage

### DIFF
--- a/tests/unit/purchase.test.ts
+++ b/tests/unit/purchase.test.ts
@@ -50,7 +50,7 @@ describe("Purchase tools", () => {
         Record: [],
       });
 
-      await handlePurchaseTool("quickfile_purchase_search", {
+      const result = await handlePurchaseTool("quickfile_purchase_search", {
         status: "DELETED",
       });
 
@@ -62,6 +62,11 @@ describe("Purchase tools", () => {
           OrderDirection: "DESC",
           Status: "DELETED",
         },
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        totalRecords: 0,
+        count: 0,
+        purchases: [],
       });
     });
   });


### PR DESCRIPTION
## Summary

Strengthened the purchase search unit test for DELETED status by asserting both the QuickFile Purchase_Search request payload and the normalized handler response.

## Files Changed

tests/unit/purchase.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- --runTestsByPath tests/unit/purchase.test.ts; npm run typecheck

Resolves #72


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.58 plugin for [OpenCode](https://opencode.ai) v1.14.35 with gpt-5.5 spent 4m and 55,382 tokens on this as a headless worker.