### PR TITLE
Fix supplier search by email — Supplier_Search expects ContactEmail, not Email

### DIFF
--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -119,7 +119,7 @@ export async function handleSupplierTool(
           Offset: (args.offset as number) ?? 0,
           CompanyName: args.companyName as string | undefined,
           ContactName: args.contactName as string | undefined,
-          Email: args.email as string | undefined,
+          ContactEmail: args.email as string | undefined,
           Postcode: args.postcode as string | undefined,
         };
         const cleaned = cleanParams(params);

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -320,7 +320,7 @@ export interface Supplier {
 export interface SupplierSearchParams {
   CompanyName?: string;
   ContactName?: string;
-  Email?: string;
+  ContactEmail?: string;
   Postcode?: string;
   ReturnCount?: number;
   Offset?: number;

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for supplier tools.
+ */
+
+import { handleSupplierTool } from "../../src/tools/supplier";
+import { getApiClient } from "../../src/api/client";
+
+jest.mock("../../src/api/client", () => ({
+  getApiClient: jest.fn(),
+  QuickFileApiError: class QuickFileApiError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = "QuickFileApiError";
+    }
+  },
+}));
+
+describe("Supplier tools", () => {
+  const mockRequest = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiClient as jest.Mock).mockReturnValue({
+      request: mockRequest,
+    });
+  });
+
+  describe("quickfile_supplier_search", () => {
+    it("maps the email argument to ContactEmail in the Supplier_Search wire schema", async () => {
+      mockRequest.mockResolvedValueOnce({
+        RecordsetCount: 0,
+        ReturnCount: 0,
+        Record: [],
+      });
+
+      await handleSupplierTool("quickfile_supplier_search", {
+        email: "accounts@example.com",
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith("Supplier_Search", {
+        SearchParameters: {
+          ReturnCount: 25,
+          Offset: 0,
+          OrderResultsBy: "CompanyName",
+          OrderDirection: "ASC",
+          ContactEmail: "accounts@example.com",
+        },
+      });
+    });
+
+    it("does not send a bare Email field that the Supplier_Search endpoint would silently ignore", async () => {
+      mockRequest.mockResolvedValueOnce({
+        RecordsetCount: 0,
+        ReturnCount: 0,
+        Record: [],
+      });
+
+      await handleSupplierTool("quickfile_supplier_search", {
+        email: "accounts@example.com",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SearchParameters).not.toHaveProperty("Email");
+      expect(payload.SearchParameters).toHaveProperty(
+        "ContactEmail",
+        "accounts@example.com",
+      );
+    });
+  });
+});


### PR DESCRIPTION
When you call `quickfile_supplier_search` with the `email` filter, you get an empty result set even when a matching supplier exists. Searching by `companyName` works fine — it's only the email filter that's silently broken.

It turns out the QuickFile API uses slightly different field names for the two near-identical search endpoints:

- `Client_Search` expects `Email`, `FirstName`, `Surname`, `Telephone`.
- `Supplier_Search` expects `ContactEmail`, `ContactFirstName`, `ContactSurname`, `ContactTel`.

The MCP was sending `Email` to both, which works for clients but doesn't match anything on the supplier side. References:
- https://api.quickfile.co.uk/d/v1_2/Supplier_Search
- https://api.quickfile.co.uk/d/v1_2/Client_Search

The fix is a one-field rename inside the supplier path:

- `SupplierSearchParams.Email` becomes `SupplierSearchParams.ContactEmail` (`src/types/quickfile.ts`)
- The handler now maps the incoming arg `email` to `ContactEmail` on the wire (`src/tools/supplier.ts`)

The tool's public input schema is unchanged, so callers still pass the same `email` argument and now actually get filtered results back.

A couple of related things I noticed while comparing the two endpoint specs but kept out of this PR, since they feel like separate conversations:

- `searchSchemaProperties.contactName` isn't really a thing on either endpoint per the docs — both split the contact name into first/surname pairs.
- `searchSchemaProperties.postcode` isn't documented on either endpoint. I haven't checked what the live API actually does with it.

Happy to follow up on either if useful.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 287/287 pass. Two new unit tests in `tests/unit/supplier.test.ts` cover the wire format — they assert that `ContactEmail` is sent and that a bare `Email` field is not.
- [ ] Integration tests not run (they need live QuickFile credentials).

---

This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed supplier email search parameter mapping to correctly filter suppliers by contact email.

* **Tests**
  * Added unit tests for supplier search functionality to verify correct parameter handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->