### PR TITLE
Add quickfile_supplier_update tool

### DIFF
--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -13,7 +13,7 @@ import {
   cleanParams,
   buildAddressFromArgs,
   buildEntityData,
-  buildEntityUpdateData,
+  buildClientUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
   type ToolResult,
@@ -243,7 +243,7 @@ export async function handleClientTool(
       case "quickfile_client_update": {
         const clientId = args.clientId as number;
         const address = buildAddressFromArgs(args);
-        const entityData = buildEntityUpdateData(args, address);
+        const entityData = buildClientUpdateData(args, address);
         const updateData = { ClientID: clientId, ...entityData };
         const cleanData = cleanParams(updateData);
         await apiClient.request<

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -13,6 +13,7 @@ import {
   cleanParams,
   buildAddressFromArgs,
   buildEntityData,
+  buildSupplierUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
   type ToolResult,
@@ -62,6 +63,21 @@ export const supplierTools: Tool[] = [
     },
   },
   {
+    name: "quickfile_supplier_update",
+    description: "Update an existing supplier record",
+    inputSchema: {
+      type: "object",
+      properties: {
+        supplierId: {
+          type: "number",
+          description: "The supplier ID to update",
+        },
+        ...entitySchemaProperties,
+      },
+      required: ["supplierId"],
+    },
+  },
+  {
     name: "quickfile_supplier_delete",
     description: "Delete a supplier record (use with caution)",
     inputSchema: {
@@ -93,6 +109,15 @@ interface SupplierGetResponse {
 
 interface SupplierCreateResponse {
   SupplierID: number;
+}
+
+// Supplier_Update response shape. The endpoint is not documented in the public
+// QuickFile API reference but is functional. It returns SupplierDetailsUpdated
+// as a boolean; observed live values are unreliable (false even on a successful
+// update verified by a follow-up Supplier_Get), so the handler does not surface
+// it to callers.
+interface SupplierUpdateResponse {
+  SupplierDetailsUpdated?: boolean;
 }
 
 // =============================================================================
@@ -155,6 +180,32 @@ export async function handleSupplierTool(
           success: true,
           supplierId: response.SupplierID,
           message: `Supplier created successfully with ID ${response.SupplierID}`,
+        });
+      }
+
+      case "quickfile_supplier_update": {
+        // Notes on the wire format (verified live against the QuickFile API,
+        // none of which are in the public method reference):
+        // - The endpoint URL is /1_2/supplier/update.
+        // - The request wraps the supplier in Body.SupplierDetails — note this
+        //   is NOT symmetric with Supplier_Create (which uses Body.SupplierData)
+        //   nor with Client_Update (which uses Body.ClientData).
+        // - Contact fields use the Contact-prefixed names (ContactEmail,
+        //   ContactFirstName, …) matching Supplier_Get and Supplier_Search,
+        //   built by buildSupplierUpdateData (utils.ts).
+        const supplierId = args.supplierId as number;
+        const address = buildAddressFromArgs(args);
+        const entityData = buildSupplierUpdateData(args, address);
+        const updateData = { SupplierID: supplierId, ...entityData };
+        const cleanData = cleanParams(updateData);
+        await apiClient.request<
+          { SupplierDetails: typeof cleanData },
+          SupplierUpdateResponse
+        >("Supplier_Update", { SupplierDetails: cleanData });
+        return successResult({
+          success: true,
+          supplierId,
+          message: `Supplier #${supplierId} updated successfully`,
         });
       }
 

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -111,11 +111,10 @@ interface SupplierCreateResponse {
   SupplierID: number;
 }
 
-// Supplier_Update response shape. The endpoint is not documented in the public
-// QuickFile API reference but is functional. It returns SupplierDetailsUpdated
-// as a boolean; observed live values are unreliable (false even on a successful
-// update verified by a follow-up Supplier_Get), so the handler does not surface
-// it to callers.
+// Supplier_Update response shape. Schema: api.quickfile.co.uk/d/v1_2/Supplier_Update.
+// The endpoint returns SupplierDetailsUpdated as a boolean, but observed live
+// values are unreliable (false even on a successful update verified by a
+// follow-up Supplier_Get), so the handler does not surface it to callers.
 interface SupplierUpdateResponse {
   SupplierDetailsUpdated?: boolean;
 }
@@ -184,12 +183,9 @@ export async function handleSupplierTool(
       }
 
       case "quickfile_supplier_update": {
-        // Notes on the wire format (verified live against the QuickFile API,
-        // none of which are in the public method reference):
-        // - The endpoint URL is /1_2/supplier/update.
-        // - The request wraps the supplier in Body.SupplierDetails — note this
-        //   is NOT symmetric with Supplier_Create (which uses Body.SupplierData)
-        //   nor with Client_Update (which uses Body.ClientData).
+        // Wire-format notes (schema: api.quickfile.co.uk/d/v1_2/Supplier_Update):
+        // - Body wraps the supplier in SupplierDetails (same wrapper as
+        //   Supplier_Create; the client endpoints use ClientData instead).
         // - Contact fields use the Contact-prefixed names (ContactEmail,
         //   ContactFirstName, …) matching Supplier_Get and Supplier_Search,
         //   built by buildSupplierUpdateData (utils.ts).

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -550,11 +550,60 @@ export function buildEntityData(
 }
 
 /**
- * Build entity update data (preserves undefined for partial updates)
+ * Build client update data (preserves undefined for partial updates).
+ * Uses the bare field names (Email, FirstName, Surname, Telephone) that the
+ * Client_Update endpoint expects. The supplier equivalent lives below — they
+ * are kept side-by-side rather than collapsed into one shared helper because
+ * the two endpoints use different wire-level field names for contact details:
+ * suppliers prefix them with "Contact" (ContactEmail, ContactFirstName, …).
  */
-export function buildEntityUpdateData(
+export function buildClientUpdateData(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
   return extractEntityFields(args, address);
+}
+
+/**
+ * Build supplier update data (preserves undefined for partial updates).
+ * Mirrors buildClientUpdateData but emits the Contact-prefixed wire names
+ * required by Supplier_Update / Supplier_Get / Supplier_Search.
+ */
+export interface SupplierEntityData {
+  CompanyName?: string;
+  Title?: string;
+  ContactFirstName?: string;
+  ContactSurname?: string;
+  ContactEmail?: string;
+  ContactTelephone?: string;
+  ContactMobile?: string;
+  Website?: string;
+  VatNumber?: string;
+  CompanyRegNo?: string;
+  Currency?: string;
+  TermDays?: number;
+  Notes?: string;
+  Address?: ClientAddress;
+}
+
+export function buildSupplierUpdateData(
+  args: Record<string, unknown>,
+  address: ClientAddress,
+): SupplierEntityData {
+  return {
+    CompanyName: args.companyName as string | undefined,
+    Title: args.title as string | undefined,
+    ContactFirstName: args.firstName as string | undefined,
+    ContactSurname: args.lastName as string | undefined,
+    ContactEmail: args.email as string | undefined,
+    ContactTelephone: args.telephone as string | undefined,
+    ContactMobile: args.mobile as string | undefined,
+    Website: args.website as string | undefined,
+    VatNumber: args.vatNumber as string | undefined,
+    CompanyRegNo: args.companyRegNo as string | undefined,
+    Currency: args.currency as string | undefined,
+    TermDays: args.termDays as number | undefined,
+    Notes: args.notes as string | undefined,
+    Address: Object.keys(address).length > 0 ? address : undefined,
+  };
 }

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for supplier tools.
+ */
+
+import { handleSupplierTool, supplierTools } from "../../src/tools/supplier";
+import { getApiClient } from "../../src/api/client";
+
+jest.mock("../../src/api/client", () => ({
+  getApiClient: jest.fn(),
+  QuickFileApiError: class QuickFileApiError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = "QuickFileApiError";
+    }
+  },
+}));
+
+describe("Supplier tools", () => {
+  const mockRequest = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiClient as jest.Mock).mockReturnValue({
+      request: mockRequest,
+    });
+  });
+
+  describe("quickfile_supplier_update", () => {
+    it("declares supplierId as a required input", () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_update",
+      );
+
+      expect(tool?.inputSchema).toMatchObject({
+        properties: {
+          supplierId: { type: "number" },
+        },
+        required: ["supplierId"],
+      });
+    });
+
+    it("wraps the payload in SupplierDetails (not SupplierData)", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 12345,
+        email: "accounts@example.com",
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith("Supplier_Update", {
+        SupplierDetails: {
+          SupplierID: 12345,
+          ContactEmail: "accounts@example.com",
+        },
+      });
+    });
+
+    it("sends contact fields with the Contact-prefixed wire names", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 99,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.com",
+        telephone: "020 7946 0000",
+        mobile: "07700 900123",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toEqual({
+        SupplierID: 99,
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+        ContactEmail: "ada@example.com",
+        ContactTelephone: "020 7946 0000",
+        ContactMobile: "07700 900123",
+      });
+      // Negative assertions: the client-style bare field names must never appear
+      // — the Supplier_Update endpoint silently ignores them.
+      expect(payload.SupplierDetails).not.toHaveProperty("Email");
+      expect(payload.SupplierDetails).not.toHaveProperty("FirstName");
+      expect(payload.SupplierDetails).not.toHaveProperty("Surname");
+      expect(payload.SupplierDetails).not.toHaveProperty("Telephone");
+      expect(payload.SupplierDetails).not.toHaveProperty("Mobile");
+    });
+
+    it("omits undefined fields so it acts as a true partial update", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 42,
+        email: "x@example.com",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      // Only the two fields the caller supplied; nothing else creeps in.
+      expect(Object.keys(payload.SupplierDetails).sort()).toEqual([
+        "ContactEmail",
+        "SupplierID",
+      ]);
+    });
+
+    it("returns a stable success result that does not expose the misleading SupplierDetailsUpdated boolean", async () => {
+      // Live observation (2026-05-13): the QuickFile API returns
+      // SupplierDetailsUpdated: false even after a successful update verified
+      // by a follow-up Supplier_Get. The handler must not surface this flag.
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      const result = await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 7,
+        email: "x@example.com",
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({
+        success: true,
+        supplierId: 7,
+        message: "Supplier #7 updated successfully",
+      });
+      expect(parsed).not.toHaveProperty("SupplierDetailsUpdated");
+    });
+
+    it("includes the address block only when at least one address field is provided", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        postcode: "TF9 4LA",
+      });
+
+      const [, withAddress] = mockRequest.mock.calls[0];
+      expect(withAddress.SupplierDetails).toHaveProperty("Address", {
+        Postcode: "TF9 4LA",
+      });
+
+      mockRequest.mockClear();
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        email: "x@example.com",
+      });
+
+      const [, withoutAddress] = mockRequest.mock.calls[0];
+      expect(withoutAddress.SupplierDetails).not.toHaveProperty("Address");
+    });
+  });
+});


### PR DESCRIPTION
Most of the supplier tools already cover the basics — create, get, search, delete — but there isn't an update yet, which means filling in a missing field on an existing supplier (e.g. `ContactEmail`) currently has to happen in the web UI. This PR adds `quickfile_supplier_update` as a sibling to `quickfile_client_update`: same partial-update behaviour, same input shape.

The shared update-data helper has been renamed for accuracy. `buildEntityUpdateData` was named as if it worked for any entity, but only ever did the right thing for clients — it emits the bare contact field names (`Email`, `FirstName`, …) that `Client_Update` expects. Suppliers need the `Contact`-prefixed names, so the helper is now `buildClientUpdateData`, with a parallel `buildSupplierUpdateData` next to it in `src/tools/utils.ts`. The create-side helper `buildEntityData` is left alone for this PR — it's still genuinely shared between the client and supplier create paths today, and untangling the same divergence there belongs in a separate follow-up (see note at the bottom).

Two wire-format details worth documenting:

- The request wraps the payload in `SupplierDetails` — same wrapper key as `Supplier_Create`. Contact fields use the `Contact`-prefixed names (`ContactEmail`, `ContactFirstName`, …) that `Supplier_Get` returns, not the bare names (`Email`, `FirstName`, …) that the client endpoints use. Same supplier-vs-client divergence that 42700fa documented for `Supplier_Search`.
- The response field `SupplierDetailsUpdated` comes back `false` even on a successful write — confirmed by re-fetching the supplier afterwards and seeing the new value persisted. The tool returns the standard `{success, supplierId, message}` shape used by the other write methods rather than passing the flag through. QFSteve has flagged this as a bug to investigate.

Context: these were raised on the [QuickFile community forum](https://community.quickfile.co.uk/t/three-small-questions-about-supplier-update-method/64653). The schema page for `Supplier_Update` is reachable at https://api.quickfile.co.uk/d/v1_2/Supplier_Update; QFSteve has confirmed the method-reference index will be updated.

> **Correction to an earlier version of this description.** An earlier draft of this PR body claimed `Supplier_Create` used a `SupplierData` wrapper and that `Supplier_Update` was therefore asymmetric — that was wrong. A live probe of the API rejects `Supplier_Create` with `SupplierData` (HTTP 400, `expected: SupplierDetails`), matching QFSteve's forum reply. The current `Supplier_Create` handler in `src/tools/supplier.ts` does still send `SupplierData` and is therefore a separate bug; I'll address that (and the related Contact-prefix question on the create side) in a follow-up PR rather than bundling it into this one. Commit `c3e2028` on this branch corrects the now-misleading wire-format comments in the Update handler so the PR is internally consistent with the corrected understanding.

One thing worth flagging on the testing side: PR #78 (still open) also creates `tests/unit/supplier.test.ts` for the `Supplier_Search` fix, so whichever of these lands second will need a small rebase to merge the test file. Happy to handle that from whichever side is easier for you.

Verification:
- `npm run lint`: clean
- `npm run build`: clean (tsc, no errors)
- `npm run test`: 291/291 pass — 6 new unit tests cover the input schema, the `SupplierDetails` wrapper, the `Contact`-prefixed wire names (with negative assertions that the bare client-style names don't leak through), partial-update behaviour, the success response shape, and the conditional `Address` block.
- Live verification against the QuickFile API: used the new tool to populate `ContactEmail` on a previously-null supplier record, and confirmed via a follow-up `Supplier_Get` that the value persisted. Re-verified on 2026-05-13 as part of investigating the create-side wrapper question above.

---

_This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced supplier update functionality allowing users to modify supplier records, including contact information and address details.

* **Refactor**
  * Refactored update data builders from a generic implementation to endpoint-specific versions, providing dedicated handlers for client and supplier update operations.

* **Tests**
  * Added comprehensive unit tests for the new supplier update tool, validating payload structures, contact field naming conventions, partial updates, and address field inclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/79)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->