### PR TITLE
Fix the supplier API calls — they were sending the wrong shape

### DIFF
--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -12,7 +12,7 @@ import {
   errorResult,
   cleanParams,
   buildAddressFromArgs,
-  buildEntityData,
+  buildClientCreateData,
   buildClientUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
@@ -227,7 +227,7 @@ export async function handleClientTool(
 
       case "quickfile_client_create": {
         const address = buildAddressFromArgs(args);
-        const clientData = buildEntityData(args, address);
+        const clientData = buildClientCreateData(args, address);
         const cleanData = cleanParams(clientData);
         const response = await apiClient.request<
           { ClientData: typeof cleanData },

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -13,7 +13,7 @@ import {
   cleanParams,
   buildAddressFromArgs,
   buildEntityData,
-  buildEntityUpdateData,
+  buildClientUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
   type ToolResult,
@@ -243,7 +243,7 @@ export async function handleClientTool(
       case "quickfile_client_update": {
         const clientId = args.clientId as number;
         const address = buildAddressFromArgs(args);
-        const entityData = buildEntityUpdateData(args, address);
+        const entityData = buildClientUpdateData(args, address);
         const updateData = { ClientID: clientId, ...entityData };
         const cleanData = cleanParams(updateData);
         await apiClient.request<

--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -166,10 +166,10 @@ function buildSearchParams(
   args: Record<string, unknown>,
 ): Record<string, unknown> {
   const searchParams: Record<string, unknown> = {
-    ReturnCount: (args.returnCount as number) ?? 25,
-    Offset: (args.offset as number) ?? 0,
-    OrderResultsBy: (args.orderBy as string) ?? "CompanyName",
-    OrderDirection: (args.orderDirection as string) ?? "ASC",
+    ReturnCount: args.returnCount ?? 25,
+    Offset: args.offset ?? 0,
+    OrderResultsBy: args.orderBy ?? "CompanyName",
+    OrderDirection: args.orderDirection ?? "ASC",
   };
 
   if (args.companyName) {

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -13,6 +13,7 @@ import {
   cleanParams,
   buildAddressFromArgs,
   buildEntityData,
+  buildSupplierUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
   type ToolResult,
@@ -62,6 +63,21 @@ export const supplierTools: Tool[] = [
     },
   },
   {
+    name: "quickfile_supplier_update",
+    description: "Update an existing supplier record",
+    inputSchema: {
+      type: "object",
+      properties: {
+        supplierId: {
+          type: "number",
+          description: "The supplier ID to update",
+        },
+        ...entitySchemaProperties,
+      },
+      required: ["supplierId"],
+    },
+  },
+  {
     name: "quickfile_supplier_delete",
     description: "Delete a supplier record (use with caution)",
     inputSchema: {
@@ -93,6 +109,15 @@ interface SupplierGetResponse {
 
 interface SupplierCreateResponse {
   SupplierID: number;
+}
+
+// Supplier_Update response shape. The endpoint is not documented in the public
+// QuickFile API reference but is functional. It returns SupplierDetailsUpdated
+// as a boolean; observed live values are unreliable (false even on a successful
+// update verified by a follow-up Supplier_Get), so the handler does not surface
+// it to callers.
+interface SupplierUpdateResponse {
+  SupplierDetailsUpdated?: boolean;
 }
 
 // =============================================================================
@@ -155,6 +180,32 @@ export async function handleSupplierTool(
           success: true,
           supplierId: response.SupplierID,
           message: `Supplier created successfully with ID ${response.SupplierID}`,
+        });
+      }
+
+      case "quickfile_supplier_update": {
+        // Notes on the wire format (verified live against the QuickFile API,
+        // none of which are in the public method reference):
+        // - The endpoint URL is /1_2/supplier/update.
+        // - The request wraps the supplier in Body.SupplierDetails — note this
+        //   is NOT symmetric with Supplier_Create (which uses Body.SupplierData)
+        //   nor with Client_Update (which uses Body.ClientData).
+        // - Contact fields use the Contact-prefixed names (ContactEmail,
+        //   ContactFirstName, …) matching Supplier_Get and Supplier_Search,
+        //   built by buildSupplierUpdateData (utils.ts).
+        const supplierId = args.supplierId as number;
+        const address = buildAddressFromArgs(args);
+        const entityData = buildSupplierUpdateData(args, address);
+        const updateData = { SupplierID: supplierId, ...entityData };
+        const cleanData = cleanParams(updateData);
+        await apiClient.request<
+          { SupplierDetails: typeof cleanData },
+          SupplierUpdateResponse
+        >("Supplier_Update", { SupplierDetails: cleanData });
+        return successResult({
+          success: true,
+          supplierId,
+          message: `Supplier #${supplierId} updated successfully`,
         });
       }
 

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -111,11 +111,10 @@ interface SupplierCreateResponse {
   SupplierID: number;
 }
 
-// Supplier_Update response shape. The endpoint is not documented in the public
-// QuickFile API reference but is functional. It returns SupplierDetailsUpdated
-// as a boolean; observed live values are unreliable (false even on a successful
-// update verified by a follow-up Supplier_Get), so the handler does not surface
-// it to callers.
+// Supplier_Update response shape. Schema: api.quickfile.co.uk/d/v1_2/Supplier_Update.
+// The endpoint returns SupplierDetailsUpdated as a boolean, but observed live
+// values are unreliable (false even on a successful update verified by a
+// follow-up Supplier_Get), so the handler does not surface it to callers.
 interface SupplierUpdateResponse {
   SupplierDetailsUpdated?: boolean;
 }
@@ -184,12 +183,9 @@ export async function handleSupplierTool(
       }
 
       case "quickfile_supplier_update": {
-        // Notes on the wire format (verified live against the QuickFile API,
-        // none of which are in the public method reference):
-        // - The endpoint URL is /1_2/supplier/update.
-        // - The request wraps the supplier in Body.SupplierDetails — note this
-        //   is NOT symmetric with Supplier_Create (which uses Body.SupplierData)
-        //   nor with Client_Update (which uses Body.ClientData).
+        // Wire-format notes (schema: api.quickfile.co.uk/d/v1_2/Supplier_Update):
+        // - Body wraps the supplier in SupplierDetails (same wrapper as
+        //   Supplier_Create; the client endpoints use ClientData instead).
         // - Contact fields use the Contact-prefixed names (ContactEmail,
         //   ContactFirstName, …) matching Supplier_Get and Supplier_Search,
         //   built by buildSupplierUpdateData (utils.ts).

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -11,11 +11,9 @@ import {
   successResult,
   errorResult,
   cleanParams,
-  buildAddressFromArgs,
-  buildEntityData,
+  buildSupplierCreateData,
   buildSupplierUpdateData,
-  searchSchemaProperties,
-  entitySchemaProperties,
+  supplierEntitySchemaProperties,
   type ToolResult,
 } from "./utils.js";
 
@@ -27,15 +25,53 @@ export const supplierTools: Tool[] = [
   {
     name: "quickfile_supplier_search",
     description:
-      "Search for suppliers by company name, contact name, email, or postcode. Response contains user-controlled fields (CompanyName, contact names) that are automatically sanitized.",
+      "Search for suppliers by company name, contact first/last name, contact email, or postcode. Response contains user-controlled fields (CompanyName, contact names) that are automatically sanitized.",
     inputSchema: {
       type: "object",
       properties: {
-        ...searchSchemaProperties,
+        companyName: {
+          type: "string",
+          description: "Search by company name (partial match)",
+        },
+        firstName: {
+          type: "string",
+          description: "Search by contact first name",
+        },
+        lastName: {
+          type: "string",
+          description: "Search by contact surname",
+        },
+        email: {
+          type: "string",
+          description: "Search by contact email address",
+        },
+        postcode: {
+          type: "string",
+          description: "Search by postcode",
+        },
+        showDeleted: {
+          type: "boolean",
+          description: "Include deleted suppliers in results",
+        },
+        returnCount: {
+          type: "number",
+          description: "Number of results (default: 25)",
+          default: 25,
+        },
+        offset: {
+          type: "number",
+          description: "Offset for pagination",
+          default: 0,
+        },
         orderBy: {
           type: "string",
           enum: ["CompanyName", "DateCreated", "SupplierID"],
           description: "Field to order by",
+        },
+        orderDirection: {
+          type: "string",
+          enum: ["ASC", "DESC"],
+          description: "Order direction",
         },
       },
       required: [],
@@ -44,7 +80,7 @@ export const supplierTools: Tool[] = [
   {
     name: "quickfile_supplier_get",
     description:
-      "Get detailed information about a specific supplier. Response contains user-controlled fields (CompanyName, Notes, Address, contact names) that are automatically sanitized.",
+      "Get detailed information about a specific supplier. Response contains user-controlled fields (CompanyName, contact names, address) that are automatically sanitized.",
     inputSchema: {
       type: "object",
       properties: {
@@ -55,16 +91,18 @@ export const supplierTools: Tool[] = [
   },
   {
     name: "quickfile_supplier_create",
-    description: "Create a new supplier record",
+    description:
+      "Create a new supplier record. Requires at minimum a companyName. The supplier endpoints reject several fields that the client endpoints accept (title, mobile, notes, county) — see the wire-shape table in utils.ts for the full list.",
     inputSchema: {
       type: "object",
-      properties: entitySchemaProperties,
-      required: [],
+      properties: supplierEntitySchemaProperties,
+      required: ["companyName"],
     },
   },
   {
     name: "quickfile_supplier_update",
-    description: "Update an existing supplier record",
+    description:
+      "Update an existing supplier record. All fields except supplierId are optional and only supplied fields are sent on the wire (partial update).",
     inputSchema: {
       type: "object",
       properties: {
@@ -72,7 +110,7 @@ export const supplierTools: Tool[] = [
           type: "number",
           description: "The supplier ID to update",
         },
-        ...entitySchemaProperties,
+        ...supplierEntitySchemaProperties,
       },
       required: ["supplierId"],
     },
@@ -132,6 +170,11 @@ export async function handleSupplierTool(
   try {
     switch (toolName) {
       case "quickfile_supplier_search": {
+        // Supplier_Search uses ContactEmail / ContactFirstName / ContactSurname
+        // / ContactTel — NOT the bare Email / FirstName / Surname / Telephone
+        // names that Client_Search uses. The contactName arg the old schema
+        // exposed isn't a real wire field on either endpoint, so callers now
+        // pass firstName and lastName separately.
         const params: SupplierSearchParams = {
           OrderResultsBy:
             (args.orderBy as SupplierSearchParams["OrderResultsBy"]) ??
@@ -142,9 +185,12 @@ export async function handleSupplierTool(
           ReturnCount: (args.returnCount as number) ?? 25,
           Offset: (args.offset as number) ?? 0,
           CompanyName: args.companyName as string | undefined,
-          ContactName: args.contactName as string | undefined,
-          Email: args.email as string | undefined,
+          ContactFirstName: args.firstName as string | undefined,
+          ContactSurname: args.lastName as string | undefined,
+          ContactEmail: args.email as string | undefined,
+          ContactTel: args.telephone as string | undefined,
           Postcode: args.postcode as string | undefined,
+          ShowDeleted: args.showDeleted as boolean | undefined,
         };
         const cleaned = cleanParams(params);
         const response = await apiClient.request<
@@ -168,13 +214,18 @@ export async function handleSupplierTool(
       }
 
       case "quickfile_supplier_create": {
-        const address = buildAddressFromArgs(args);
-        const supplierData = buildEntityData(args, address);
+        // Wire wrapper is SupplierDetails (NOT SupplierData — that wraps
+        // Client_Create). Address fields are flat children of SupplierDetails
+        // and contact fields use Contact-prefixed names with `ContactSurname`
+        // (lowercase n — diverges from Supplier_Update which uses ContactSurName).
+        // Defaults for currency / payment terms are nested in a Preferences
+        // block. Full wire-shape table near buildSupplierCreateData in utils.ts.
+        const supplierData = buildSupplierCreateData(args);
         const cleanData = cleanParams(supplierData);
         const response = await apiClient.request<
-          { SupplierData: typeof cleanData },
+          { SupplierDetails: typeof cleanData },
           SupplierCreateResponse
-        >("Supplier_Create", { SupplierData: cleanData });
+        >("Supplier_Create", { SupplierDetails: cleanData });
         return successResult({
           success: true,
           supplierId: response.SupplierID,
@@ -183,15 +234,12 @@ export async function handleSupplierTool(
       }
 
       case "quickfile_supplier_update": {
-        // Wire-format notes (schema: api.quickfile.co.uk/d/v1_2/Supplier_Update):
-        // - Body wraps the supplier in SupplierDetails (same wrapper as
-        //   Supplier_Create; the client endpoints use ClientData instead).
-        // - Contact fields use the Contact-prefixed names (ContactEmail,
-        //   ContactFirstName, …) matching Supplier_Get and Supplier_Search,
-        //   built by buildSupplierUpdateData (utils.ts).
+        // Wire wrapper is SupplierDetails (same as Supplier_Create). Contact
+        // surname uses CAPITAL N (`ContactSurName`) — Supplier_Update and
+        // Supplier_Create diverge on this one field name. See the wire-format
+        // anchor near buildSupplierUpdateData in utils.ts.
         const supplierId = args.supplierId as number;
-        const address = buildAddressFromArgs(args);
-        const entityData = buildSupplierUpdateData(args, address);
+        const entityData = buildSupplierUpdateData(args);
         const updateData = { SupplierID: supplierId, ...entityData };
         const cleanData = cleanParams(updateData);
         await apiClient.request<

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -25,7 +25,7 @@ export const supplierTools: Tool[] = [
   {
     name: "quickfile_supplier_search",
     description:
-      "Search for suppliers by company name, contact first/last name, contact email, or postcode. Response contains user-controlled fields (CompanyName, contact names) that are automatically sanitized.",
+      "Search for suppliers by company name, contact first/last name, contact email, telephone, supplier reference, or postcode. Response contains user-controlled fields (CompanyName, contact names) that are automatically sanitized.",
     inputSchema: {
       type: "object",
       properties: {
@@ -44,6 +44,14 @@ export const supplierTools: Tool[] = [
         email: {
           type: "string",
           description: "Search by contact email address",
+        },
+        telephone: {
+          type: "string",
+          description: "Search by contact telephone number",
+        },
+        supplierReference: {
+          type: "string",
+          description: "Search by supplier reference",
         },
         postcode: {
           type: "string",
@@ -189,6 +197,7 @@ export async function handleSupplierTool(
           ContactSurname: args.lastName as string | undefined,
           ContactEmail: args.email as string | undefined,
           ContactTel: args.telephone as string | undefined,
+          SupplierReference: args.supplierReference as string | undefined,
           Postcode: args.postcode as string | undefined,
           ShowDeleted: args.showDeleted as boolean | undefined,
         };

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -371,7 +371,13 @@ export const lineItemSchemaProperties = {
 };
 
 /**
- * Common entity properties for create/update tools
+ * Common entity properties for client create/update tools.
+ *
+ * Suppliers use a narrower schema (see `supplierEntitySchemaProperties`) because
+ * the Supplier_Create / Supplier_Update endpoints reject several fields that
+ * Client_Create / Client_Update accept (title, mobile, notes, county,
+ * companyRegNo, an Address block — see the wire-shape table near
+ * buildSupplierCreateData).
  */
 export const entitySchemaProperties = {
   companyName: {
@@ -454,12 +460,170 @@ export const entitySchemaProperties = {
   },
 };
 
+/**
+ * Supplier-specific entity properties for supplier create/update tools.
+ *
+ * Drops the args the QuickFile supplier endpoints reject with HTTP 400 on the
+ * wire: `title`, `mobile`, `notes`, `county`, `companyRegNo` (which the API
+ * renames to `CompanyNumber` — see `buildSupplierCreateData`). Keeps `address3`
+ * which the supplier endpoints accept but clients do not expose, and uses
+ * `countryIso` rather than `country` to match the wire field name.
+ */
+export const supplierEntitySchemaProperties = {
+  companyName: {
+    type: "string" as const,
+    description: "Company or organisation name",
+  },
+  companyNumber: {
+    type: "string" as const,
+    description: "Company registration number",
+  },
+  supplierReference: {
+    type: "string" as const,
+    description: "Free-form supplier reference (max 15 chars)",
+  },
+  firstName: {
+    type: "string" as const,
+    description: "Contact first name",
+  },
+  lastName: {
+    type: "string" as const,
+    description: "Contact last name",
+  },
+  email: {
+    type: "string" as const,
+    description: "Contact email address",
+  },
+  telephone: {
+    type: "string" as const,
+    description: "Contact telephone number",
+  },
+  website: {
+    type: "string" as const,
+    description: "Website URL",
+  },
+  address1: {
+    type: "string" as const,
+    description: "Address line 1",
+  },
+  address2: {
+    type: "string" as const,
+    description: "Address line 2",
+  },
+  address3: {
+    type: "string" as const,
+    description: "Address line 3",
+  },
+  town: {
+    type: "string" as const,
+    description: "Town/City",
+  },
+  postcode: {
+    type: "string" as const,
+    description: "Postcode",
+  },
+  countryIso: {
+    type: "string" as const,
+    description: "ISO 3166-1 alpha-2 country code (e.g., GB)",
+  },
+  vatNumber: {
+    type: "string" as const,
+    description: "VAT registration number",
+  },
+  vatExempt: {
+    type: "boolean" as const,
+    description: "Whether the supplier is VAT-exempt",
+  },
+  currency: {
+    type: "string" as const,
+    description: "Default currency (e.g., GBP). Sent as Preferences.DefaultCurrency on the wire.",
+    default: "GBP",
+  },
+  termDays: {
+    type: "number" as const,
+    description: "Default payment terms in days. Sent as Preferences.DefaultTerm on the wire.",
+    default: 30,
+  },
+  defaultVatRate: {
+    type: "number" as const,
+    description: "Default VAT rate (e.g., 20). Sent as Preferences.DefaultVatRate on the wire.",
+  },
+  defaultNominalCode: {
+    type: "number" as const,
+    description: "Default nominal code (5000-9997). Sent as Preferences.DefaultNominalCode on the wire.",
+  },
+};
+
 // =============================================================================
-// Shared Entity Builders (Client/Supplier)
+// Entity Builders (Client / Supplier)
 // =============================================================================
 
+/*
+ * Wire-format anchor for QuickFile supplier endpoints (last live-verified
+ * 2026-05-14 by direct-script probes against the live API).
+ *
+ * QuickFile's Client_* and Supplier_* endpoints look near-identical but diverge
+ * in three load-bearing ways. The helpers below are split to honour each
+ * endpoint's actual wire shape rather than trying to share a single mapping.
+ *
+ * --- Wrappers (Body child element) -----------------------------------------
+ *
+ *   Client_Create   → <ClientData>…</ClientData>
+ *   Client_Update   → <ClientData>…</ClientData>          (+ ClientID inside)
+ *   Supplier_Create → <SupplierDetails>…</SupplierDetails>
+ *   Supplier_Update → <SupplierDetails>…</SupplierDetails> (+ SupplierID inside)
+ *   Supplier_Search → <SearchParameters>…</SearchParameters>
+ *
+ * --- Contact-field naming --------------------------------------------------
+ *
+ *   Client_*        bare names: FirstName, LastName, Email, Telephone, Mobile
+ *   Supplier_Create Contact-prefixed: ContactFirstName, ContactSurname (lowercase n),
+ *                   ContactEmail, ContactTel.  No mobile field.
+ *   Supplier_Update Contact-prefixed: ContactFirstName, ContactSurName (CAPITAL N),
+ *                   ContactEmail, ContactTel.  No mobile field.
+ *   Supplier_Search Contact-prefixed: ContactFirstName, ContactSurname (lowercase n),
+ *                   ContactEmail, ContactTel.
+ *
+ *   Yes — the Surname field's casing differs between Supplier_Create (lowercase
+ *   n) and Supplier_Update (capital N). QuickFile is genuinely inconsistent
+ *   here; we verified this against the live API on 2026-05-14.
+ *
+ * --- Defaults block (currency, term, VAT rate, nominal code) ---------------
+ *
+ *   Client_*        flat at root: Currency, TermDays
+ *   Supplier_*      nested in a Preferences block:
+ *                     Preferences.DefaultCurrency, Preferences.DefaultTerm,
+ *                     Preferences.DefaultVatRate, Preferences.DefaultNominalCode
+ *
+ * --- Address fields --------------------------------------------------------
+ *
+ *   Client_*        nested <Address>: Address1, Address2, Town, County,
+ *                   Postcode, Country
+ *   Supplier_*      flat at root of SupplierDetails: AddressLine1, AddressLine2,
+ *                   AddressLine3, Town, Postcode, CountryISO
+ *                   (no County field; if needed, fold into AddressLine3)
+ *
+ * --- Fields the Supplier endpoints reject (HTTP 400) -----------------------
+ *
+ *   Title, Notes, ContactMobile, County, CompanyRegNo (must be CompanyNumber),
+ *   bare Email/FirstName/LastName/Telephone, top-level Currency/TermDays.
+ *
+ * --- Read/write asymmetry --------------------------------------------------
+ *
+ *   Supplier_Get's response keys do not match the write shape. Get returns
+ *   ContactSurname (lowercase n), ContactTelephone (long), and the default
+ *   currency/term flat at the root — not in a Preferences block. A Get response
+ *   cannot be round-tripped directly into Supplier_Update without remapping.
+ *
+ * To re-verify any of the above: send the relevant endpoint a SupplierDetails
+ * payload containing one unknown child element. The 400 response includes the
+ * full accepted-element list. Repeat for Client_Create / Client_Update with
+ * the relevant wrappers.
+ */
+
 /**
- * Common entity data structure for clients and suppliers
+ * Common entity data structure for clients (bare field names matching the
+ * Client_Create / Client_Update wire shape).
  */
 export interface EntityData {
   CompanyName?: string;
@@ -479,8 +643,10 @@ export interface EntityData {
 }
 
 /**
- * Build address object from tool arguments
- * Shared between client and supplier tools
+ * Build a nested <Address> block from tool arguments. Used by the client
+ * endpoints, which accept an Address sub-object. The supplier endpoints use
+ * flat AddressLine1/2/3/Town/Postcode/CountryISO instead — see
+ * `buildSupplierAddressFields`.
  */
 export function buildAddressFromArgs(
   args: Record<string, unknown>,
@@ -508,10 +674,10 @@ export function buildAddressFromArgs(
 }
 
 /**
- * Extract common entity fields from tool arguments.
- * Shared mapping used by both create and update operations.
+ * Extract client entity fields from tool arguments.
+ * Shared mapping used by both client create and update operations.
  */
-function extractEntityFields(
+function extractClientFields(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
@@ -534,16 +700,15 @@ function extractEntityFields(
 }
 
 /**
- * Build entity data from tool arguments (for create operations).
- * Applies defaults for Currency and TermDays when not provided.
+ * Build client create data. Applies defaults for Currency and TermDays.
  */
-export function buildEntityData(
+export function buildClientCreateData(
   args: Record<string, unknown>,
   address: ClientAddress,
   defaults: { currency?: string; termDays?: number } = {},
 ): EntityData {
   const { currency = "GBP", termDays = 30 } = defaults;
-  const data = extractEntityFields(args, address);
+  const data = extractClientFields(args, address);
   data.Currency = data.Currency ?? currency;
   data.TermDays = data.TermDays ?? termDays;
   return data;
@@ -551,59 +716,196 @@ export function buildEntityData(
 
 /**
  * Build client update data (preserves undefined for partial updates).
- * Uses the bare field names (Email, FirstName, Surname, Telephone) that the
- * Client_Update endpoint expects. The supplier equivalent lives below — they
- * are kept side-by-side rather than collapsed into one shared helper because
- * the two endpoints use different wire-level field names for contact details:
- * suppliers prefix them with "Contact" (ContactEmail, ContactFirstName, …).
+ * Uses the bare field names (Email, FirstName, LastName, Telephone) that the
+ * Client_Update endpoint expects.
  */
 export function buildClientUpdateData(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
-  return extractEntityFields(args, address);
+  return extractClientFields(args, address);
+}
+
+// =============================================================================
+// Supplier-specific entity builders
+// =============================================================================
+
+/**
+ * Flat address fields as accepted by Supplier_Create / Supplier_Update.
+ * Unlike clients (nested <Address> block), supplier endpoints take address
+ * fields directly under <SupplierDetails>.
+ */
+export interface SupplierAddressFields {
+  AddressLine1?: string;
+  AddressLine2?: string;
+  AddressLine3?: string;
+  Town?: string;
+  Postcode?: string;
+  CountryISO?: string;
 }
 
 /**
- * Build supplier update data (preserves undefined for partial updates).
- * Mirrors buildClientUpdateData but emits the Contact-prefixed wire names
- * required by Supplier_Update / Supplier_Get / Supplier_Search.
+ * Build the flat address fields supplier endpoints expect.
+ * Reads both `country` and `countryIso` from args for caller compatibility,
+ * but emits `CountryISO` on the wire (only ISO 3166-1 alpha-2 codes are
+ * accepted, e.g. "GB", "US").
  */
-export interface SupplierEntityData {
-  CompanyName?: string;
-  Title?: string;
-  ContactFirstName?: string;
-  ContactSurname?: string;
-  ContactEmail?: string;
-  ContactTelephone?: string;
-  ContactMobile?: string;
-  Website?: string;
-  VatNumber?: string;
-  CompanyRegNo?: string;
-  Currency?: string;
-  TermDays?: number;
-  Notes?: string;
-  Address?: ClientAddress;
+export function buildSupplierAddressFields(
+  args: Record<string, unknown>,
+): SupplierAddressFields {
+  const fields: SupplierAddressFields = {};
+  if (args.address1) {
+    fields.AddressLine1 = args.address1 as string;
+  }
+  if (args.address2) {
+    fields.AddressLine2 = args.address2 as string;
+  }
+  if (args.address3) {
+    fields.AddressLine3 = args.address3 as string;
+  }
+  if (args.town) {
+    fields.Town = args.town as string;
+  }
+  if (args.postcode) {
+    fields.Postcode = args.postcode as string;
+  }
+  if (args.countryIso) {
+    fields.CountryISO = args.countryIso as string;
+  } else if (args.country) {
+    // Best-effort compatibility: accept `country` and emit it as CountryISO if
+    // it already looks like a 2-letter code; otherwise drop it (the API rejects
+    // anything that isn't a valid ISO alpha-2 code).
+    const value = (args.country as string).trim();
+    if (/^[A-Za-z]{2}$/.test(value)) {
+      fields.CountryISO = value.toUpperCase();
+    }
+  }
+  return fields;
 }
 
-export function buildSupplierUpdateData(
+/**
+ * Preferences block accepted by Supplier_Create / Supplier_Update.
+ */
+export interface SupplierPreferences {
+  DefaultCurrency?: string;
+  DefaultTerm?: number;
+  DefaultVatRate?: number;
+  DefaultNominalCode?: number;
+}
+
+/**
+ * Build a Preferences block from tool arguments, or undefined when no
+ * preference-related arg was supplied (so partial updates don't smuggle in
+ * an empty Preferences block).
+ */
+function buildSupplierPreferences(
   args: Record<string, unknown>,
-  address: ClientAddress,
-): SupplierEntityData {
-  return {
+): SupplierPreferences | undefined {
+  const prefs: SupplierPreferences = {};
+  if (args.currency !== undefined) {
+    prefs.DefaultCurrency = args.currency as string;
+  }
+  if (args.termDays !== undefined) {
+    prefs.DefaultTerm = args.termDays as number;
+  }
+  if (args.defaultVatRate !== undefined) {
+    prefs.DefaultVatRate = args.defaultVatRate as number;
+  }
+  if (args.defaultNominalCode !== undefined) {
+    prefs.DefaultNominalCode = args.defaultNominalCode as number;
+  }
+  return Object.keys(prefs).length > 0 ? prefs : undefined;
+}
+
+/**
+ * Supplier_Create wire-shape body. Surname uses lowercase `n`.
+ */
+export interface SupplierCreateData extends SupplierAddressFields {
+  CompanyName?: string;
+  CompanyNumber?: string;
+  SupplierReference?: string;
+  ContactFirstName?: string;
+  ContactSurname?: string;
+  ContactTel?: string;
+  ContactEmail?: string;
+  Website?: string;
+  VatNumber?: string;
+  VatExempt?: boolean;
+  Preferences?: SupplierPreferences;
+}
+
+/**
+ * Build the body for Supplier_Create. Applies defaults for currency (GBP) and
+ * payment terms (30 days) into the Preferences block when neither is supplied.
+ */
+export function buildSupplierCreateData(
+  args: Record<string, unknown>,
+  defaults: { currency?: string; termDays?: number } = {},
+): SupplierCreateData {
+  const { currency = "GBP", termDays = 30 } = defaults;
+
+  // Pre-apply defaults so they land inside the Preferences block.
+  const argsWithDefaults = {
+    ...args,
+    currency: args.currency ?? currency,
+    termDays: args.termDays ?? termDays,
+  };
+
+  const data: SupplierCreateData = {
     CompanyName: args.companyName as string | undefined,
-    Title: args.title as string | undefined,
+    CompanyNumber: args.companyNumber as string | undefined,
+    SupplierReference: args.supplierReference as string | undefined,
     ContactFirstName: args.firstName as string | undefined,
     ContactSurname: args.lastName as string | undefined,
+    ContactTel: args.telephone as string | undefined,
     ContactEmail: args.email as string | undefined,
-    ContactTelephone: args.telephone as string | undefined,
-    ContactMobile: args.mobile as string | undefined,
     Website: args.website as string | undefined,
     VatNumber: args.vatNumber as string | undefined,
-    CompanyRegNo: args.companyRegNo as string | undefined,
-    Currency: args.currency as string | undefined,
-    TermDays: args.termDays as number | undefined,
-    Notes: args.notes as string | undefined,
-    Address: Object.keys(address).length > 0 ? address : undefined,
+    VatExempt: args.vatExempt as boolean | undefined,
+    Preferences: buildSupplierPreferences(argsWithDefaults),
+    ...buildSupplierAddressFields(args),
+  };
+  return data;
+}
+
+/**
+ * Supplier_Update wire-shape body. Surname uses CAPITAL `N` — Supplier_Update
+ * and Supplier_Create diverge on this one field name. See the wire-format
+ * anchor above for the verified accepted-element lists from each endpoint.
+ */
+export interface SupplierUpdateData extends SupplierAddressFields {
+  CompanyName?: string;
+  CompanyNumber?: string;
+  SupplierReference?: string;
+  ContactFirstName?: string;
+  ContactSurName?: string;
+  ContactTel?: string;
+  ContactEmail?: string;
+  Website?: string;
+  VatNumber?: string;
+  VatExempt?: boolean;
+  Preferences?: SupplierPreferences;
+}
+
+/**
+ * Build the body for Supplier_Update (preserves undefined for partial updates;
+ * never injects defaults — the caller may be touching only one field).
+ */
+export function buildSupplierUpdateData(
+  args: Record<string, unknown>,
+): SupplierUpdateData {
+  return {
+    CompanyName: args.companyName as string | undefined,
+    CompanyNumber: args.companyNumber as string | undefined,
+    SupplierReference: args.supplierReference as string | undefined,
+    ContactFirstName: args.firstName as string | undefined,
+    ContactSurName: args.lastName as string | undefined,
+    ContactTel: args.telephone as string | undefined,
+    ContactEmail: args.email as string | undefined,
+    Website: args.website as string | undefined,
+    VatNumber: args.vatNumber as string | undefined,
+    VatExempt: args.vatExempt as boolean | undefined,
+    Preferences: buildSupplierPreferences(args),
+    ...buildSupplierAddressFields(args),
   };
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -550,11 +550,60 @@ export function buildEntityData(
 }
 
 /**
- * Build entity update data (preserves undefined for partial updates)
+ * Build client update data (preserves undefined for partial updates).
+ * Uses the bare field names (Email, FirstName, Surname, Telephone) that the
+ * Client_Update endpoint expects. The supplier equivalent lives below — they
+ * are kept side-by-side rather than collapsed into one shared helper because
+ * the two endpoints use different wire-level field names for contact details:
+ * suppliers prefix them with "Contact" (ContactEmail, ContactFirstName, …).
  */
-export function buildEntityUpdateData(
+export function buildClientUpdateData(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
   return extractEntityFields(args, address);
+}
+
+/**
+ * Build supplier update data (preserves undefined for partial updates).
+ * Mirrors buildClientUpdateData but emits the Contact-prefixed wire names
+ * required by Supplier_Update / Supplier_Get / Supplier_Search.
+ */
+export interface SupplierEntityData {
+  CompanyName?: string;
+  Title?: string;
+  ContactFirstName?: string;
+  ContactSurname?: string;
+  ContactEmail?: string;
+  ContactTelephone?: string;
+  ContactMobile?: string;
+  Website?: string;
+  VatNumber?: string;
+  CompanyRegNo?: string;
+  Currency?: string;
+  TermDays?: number;
+  Notes?: string;
+  Address?: ClientAddress;
+}
+
+export function buildSupplierUpdateData(
+  args: Record<string, unknown>,
+  address: ClientAddress,
+): SupplierEntityData {
+  return {
+    CompanyName: args.companyName as string | undefined,
+    Title: args.title as string | undefined,
+    ContactFirstName: args.firstName as string | undefined,
+    ContactSurname: args.lastName as string | undefined,
+    ContactEmail: args.email as string | undefined,
+    ContactTelephone: args.telephone as string | undefined,
+    ContactMobile: args.mobile as string | undefined,
+    Website: args.website as string | undefined,
+    VatNumber: args.vatNumber as string | undefined,
+    CompanyRegNo: args.companyRegNo as string | undefined,
+    Currency: args.currency as string | undefined,
+    TermDays: args.termDays as number | undefined,
+    Notes: args.notes as string | undefined,
+    Address: Object.keys(address).length > 0 ? address : undefined,
+  };
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -746,9 +746,10 @@ export interface SupplierAddressFields {
 
 /**
  * Build the flat address fields supplier endpoints expect.
- * Reads both `country` and `countryIso` from args for caller compatibility,
- * but emits `CountryISO` on the wire (only ISO 3166-1 alpha-2 codes are
- * accepted, e.g. "GB", "US").
+ * Reads both `countryIso` (preferred) and `country` (legacy) from args for
+ * caller compatibility, but emits `CountryISO` on the wire only when the
+ * value is a valid ISO 3166-1 alpha-2 code (e.g. "GB", "US"). Anything else
+ * is dropped rather than sent — the API rejects non-ISO values.
  */
 export function buildSupplierAddressFields(
   args: Record<string, unknown>,
@@ -769,13 +770,14 @@ export function buildSupplierAddressFields(
   if (args.postcode) {
     fields.Postcode = args.postcode as string;
   }
-  if (args.countryIso) {
-    fields.CountryISO = args.countryIso as string;
-  } else if (args.country) {
-    // Best-effort compatibility: accept `country` and emit it as CountryISO if
-    // it already looks like a 2-letter code; otherwise drop it (the API rejects
-    // anything that isn't a valid ISO alpha-2 code).
-    const value = (args.country as string).trim();
+  const rawCountry =
+    typeof args.countryIso === "string"
+      ? args.countryIso
+      : typeof args.country === "string"
+        ? args.country
+        : undefined;
+  if (rawCountry) {
+    const value = rawCountry.trim();
     if (/^[A-Za-z]{2}$/.test(value)) {
       fields.CountryISO = value.toUpperCase();
     }

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -318,10 +318,20 @@ export interface Supplier {
 }
 
 export interface SupplierSearchParams {
+  // Field names match Supplier_Search's accepted wire elements verified
+  // against the live API on 2026-05-14. Supplier_Search uses Contact-prefixed
+  // names (ContactEmail, ContactFirstName, ContactSurname, ContactTel) while
+  // Client_Search uses bare names (Email, FirstName, Surname, Telephone) for
+  // the same concepts. The combined ContactName field that earlier versions
+  // exposed isn't a real wire element on either endpoint.
   CompanyName?: string;
-  ContactName?: string;
-  Email?: string;
+  ContactFirstName?: string;
+  ContactSurname?: string;
+  ContactEmail?: string;
+  ContactTel?: string;
+  SupplierReference?: string;
   Postcode?: string;
+  ShowDeleted?: boolean;
   ReturnCount?: number;
   Offset?: number;
   OrderResultsBy?: 'CompanyName' | 'DateCreated' | 'SupplierID';

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for supplier tools.
+ */
+
+import { handleSupplierTool, supplierTools } from "../../src/tools/supplier";
+import { getApiClient } from "../../src/api/client";
+
+jest.mock("../../src/api/client", () => ({
+  getApiClient: jest.fn(),
+  QuickFileApiError: class QuickFileApiError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = "QuickFileApiError";
+    }
+  },
+}));
+
+describe("Supplier tools", () => {
+  const mockRequest = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiClient as jest.Mock).mockReturnValue({
+      request: mockRequest,
+    });
+  });
+
+  describe("quickfile_supplier_update", () => {
+    it("declares supplierId as a required input", () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_update",
+      );
+
+      expect(tool?.inputSchema).toMatchObject({
+        properties: {
+          supplierId: { type: "number" },
+        },
+        required: ["supplierId"],
+      });
+    });
+
+    it("wraps the payload in SupplierDetails (not SupplierData)", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 12345,
+        email: "accounts@example.com",
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith("Supplier_Update", {
+        SupplierDetails: {
+          SupplierID: 12345,
+          ContactEmail: "accounts@example.com",
+        },
+      });
+    });
+
+    it("sends contact fields with the Contact-prefixed wire names", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 99,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.com",
+        telephone: "020 7946 0000",
+        mobile: "07700 900123",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toEqual({
+        SupplierID: 99,
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+        ContactEmail: "ada@example.com",
+        ContactTelephone: "020 7946 0000",
+        ContactMobile: "07700 900123",
+      });
+      // Negative assertions: the client-style bare field names must never appear
+      // — the Supplier_Update endpoint silently ignores them.
+      expect(payload.SupplierDetails).not.toHaveProperty("Email");
+      expect(payload.SupplierDetails).not.toHaveProperty("FirstName");
+      expect(payload.SupplierDetails).not.toHaveProperty("Surname");
+      expect(payload.SupplierDetails).not.toHaveProperty("Telephone");
+      expect(payload.SupplierDetails).not.toHaveProperty("Mobile");
+    });
+
+    it("omits undefined fields so it acts as a true partial update", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 42,
+        email: "x@example.com",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      // Only the two fields the caller supplied; nothing else creeps in.
+      expect(Object.keys(payload.SupplierDetails).sort()).toEqual([
+        "ContactEmail",
+        "SupplierID",
+      ]);
+    });
+
+    it("returns a stable success result that does not expose the misleading SupplierDetailsUpdated boolean", async () => {
+      // Live observation (2026-05-13): the QuickFile API returns
+      // SupplierDetailsUpdated: false even after a successful update verified
+      // by a follow-up Supplier_Get. The handler must not surface this flag.
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      const result = await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 7,
+        email: "x@example.com",
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual({
+        success: true,
+        supplierId: 7,
+        message: "Supplier #7 updated successfully",
+      });
+      expect(parsed).not.toHaveProperty("SupplierDetailsUpdated");
+    });
+
+    it("includes the address block only when at least one address field is provided", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        postcode: "TF9 4LA",
+      });
+
+      const [, withAddress] = mockRequest.mock.calls[0];
+      expect(withAddress.SupplierDetails).toHaveProperty("Address", {
+        Postcode: "TF9 4LA",
+      });
+
+      mockRequest.mockClear();
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        email: "x@example.com",
+      });
+
+      const [, withoutAddress] = mockRequest.mock.calls[0];
+      expect(withoutAddress.SupplierDetails).not.toHaveProperty("Address");
+    });
+  });
+});

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -167,6 +167,43 @@ describe("Supplier tools", () => {
       expect(payload.SupplierDetails).not.toHaveProperty("CountryISO");
     });
 
+    it("normalizes `countryIso` to uppercase before sending", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        countryIso: "gb",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails.CountryISO).toBe("GB");
+    });
+
+    it("drops non-ISO `countryIso` values just like the `country` path", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        countryIso: "United Kingdom",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).not.toHaveProperty("CountryISO");
+    });
+
+    it("prefers `countryIso` over `country` when both are supplied", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        countryIso: "US",
+        country: "GB",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails.CountryISO).toBe("US");
+    });
+
     it("nests currency / termDays / VAT rate / nominal code inside a Preferences block", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
 
@@ -354,10 +391,11 @@ describe("Supplier tools", () => {
       });
 
       const [, payload] = mockRequest.mock.calls[0];
-      expect(Object.keys(payload.SupplierDetails).sort()).toEqual([
-        "ContactEmail",
-        "SupplierID",
-      ]);
+      expect(
+        Object.keys(payload.SupplierDetails).sort((a, b) =>
+          a.localeCompare(b),
+        ),
+      ).toEqual(["ContactEmail", "SupplierID"]);
     });
 
     it("returns a stable success result that does not expose the misleading SupplierDetailsUpdated boolean", async () => {
@@ -415,6 +453,45 @@ describe("Supplier tools", () => {
       expect(payload.SearchParameters).not.toHaveProperty("ContactName");
     });
 
+    it("sends the telephone filter as ContactTel and surfaces it in the input schema", async () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_search",
+      );
+      const props = (tool?.inputSchema as { properties: Record<string, unknown> })
+        .properties;
+      expect(props).toHaveProperty("telephone");
+
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
+      await handleSupplierTool("quickfile_supplier_search", {
+        telephone: "020 7946 0000",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SearchParameters).toMatchObject({
+        ContactTel: "020 7946 0000",
+      });
+      expect(payload.SearchParameters).not.toHaveProperty("ContactTelephone");
+    });
+
+    it("sends the supplierReference filter on the wire and surfaces it in the input schema", async () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_search",
+      );
+      const props = (tool?.inputSchema as { properties: Record<string, unknown> })
+        .properties;
+      expect(props).toHaveProperty("supplierReference");
+
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
+      await handleSupplierTool("quickfile_supplier_search", {
+        supplierReference: "ACME-001",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SearchParameters).toMatchObject({
+        SupplierReference: "ACME-001",
+      });
+    });
+
     it("omits undefined fields from SearchParameters", async () => {
       mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
 
@@ -423,7 +500,11 @@ describe("Supplier tools", () => {
       });
 
       const [, payload] = mockRequest.mock.calls[0];
-      expect(Object.keys(payload.SearchParameters).sort()).toEqual([
+      expect(
+        Object.keys(payload.SearchParameters).sort((a, b) =>
+          a.localeCompare(b),
+        ),
+      ).toEqual([
         "CompanyName",
         "Offset",
         "OrderDirection",

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -1,5 +1,25 @@
 /**
  * Unit tests for supplier tools.
+ *
+ * The assertions in this file pin the QuickFile supplier wire shape verified
+ * live against the API on 2026-05-14. The full wire-format anchor lives in
+ * src/tools/utils.ts next to the build helpers — if either Supplier_Create or
+ * Supplier_Update appears to be misbehaving against the live API, re-read it
+ * before changing the assertions below. Highlights:
+ *
+ *   - Wrapper: <SupplierDetails> for both Create and Update (NOT SupplierData).
+ *   - Address: flat AddressLine1/2/3 + Town + Postcode + CountryISO on the
+ *     root of SupplierDetails (NOT a nested <Address> block).
+ *   - Preferences: <Preferences> nests DefaultCurrency / DefaultTerm /
+ *     DefaultVatRate / DefaultNominalCode (NOT flat at the root).
+ *   - Surname: Supplier_Create uses ContactSurname (lowercase n);
+ *     Supplier_Update uses ContactSurName (capital N). The casing genuinely
+ *     differs between the two endpoints.
+ *   - No fields: Title, Mobile, ContactMobile, Notes, County, CompanyRegNo —
+ *     these are accepted by the Client_* endpoints but rejected by the
+ *     Supplier_* endpoints with HTTP 400.
+ *   - Search: Supplier_Search uses ContactEmail (NOT Email); contact name
+ *     filters split into ContactFirstName + ContactSurname (NOT ContactName).
  */
 
 import { handleSupplierTool, supplierTools } from "../../src/tools/supplier";
@@ -28,6 +48,195 @@ describe("Supplier tools", () => {
     });
   });
 
+  describe("quickfile_supplier_create", () => {
+    it("declares companyName as a required input", () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_create",
+      );
+
+      expect(tool?.inputSchema).toMatchObject({
+        required: ["companyName"],
+      });
+    });
+
+    it("does not expose the supplier-rejected args (title, mobile, notes, county, companyRegNo)", () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_create",
+      );
+      const props = (tool?.inputSchema as { properties: Record<string, unknown> })
+        .properties;
+
+      expect(props).not.toHaveProperty("title");
+      expect(props).not.toHaveProperty("mobile");
+      expect(props).not.toHaveProperty("notes");
+      expect(props).not.toHaveProperty("county");
+      expect(props).not.toHaveProperty("companyRegNo");
+    });
+
+    it("wraps the payload in SupplierDetails (not SupplierData)", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        countryIso: "GB",
+      });
+
+      const [methodName, payload] = mockRequest.mock.calls[0];
+      expect(methodName).toBe("Supplier_Create");
+      expect(payload).toHaveProperty("SupplierDetails");
+      expect(payload).not.toHaveProperty("SupplierData");
+    });
+
+    it("emits Contact-prefixed contact fields with ContactSurname (lowercase n) and ContactTel", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.com",
+        telephone: "020 7946 0000",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toMatchObject({
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+        ContactEmail: "ada@example.com",
+        ContactTel: "020 7946 0000",
+      });
+      // Supplier_Create uses lowercase-n Surname; CAPITAL N would be Update.
+      expect(payload.SupplierDetails).not.toHaveProperty("ContactSurName");
+      // Client-style bare names are rejected by Supplier_Create.
+      expect(payload.SupplierDetails).not.toHaveProperty("Email");
+      expect(payload.SupplierDetails).not.toHaveProperty("FirstName");
+      expect(payload.SupplierDetails).not.toHaveProperty("LastName");
+      expect(payload.SupplierDetails).not.toHaveProperty("Telephone");
+      // Supplier_Create has no mobile field at all.
+      expect(payload.SupplierDetails).not.toHaveProperty("Mobile");
+      expect(payload.SupplierDetails).not.toHaveProperty("ContactMobile");
+    });
+
+    it("emits flat AddressLine1/2/3 + Town + Postcode + CountryISO (no nested Address block)", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        address1: "1 Example Street",
+        address2: "Industrial Estate",
+        address3: "Greater Trading Park",
+        town: "Market Drayton",
+        postcode: "TF9 4LA",
+        countryIso: "GB",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toMatchObject({
+        AddressLine1: "1 Example Street",
+        AddressLine2: "Industrial Estate",
+        AddressLine3: "Greater Trading Park",
+        Town: "Market Drayton",
+        Postcode: "TF9 4LA",
+        CountryISO: "GB",
+      });
+      expect(payload.SupplierDetails).not.toHaveProperty("Address");
+      expect(payload.SupplierDetails).not.toHaveProperty("County");
+    });
+
+    it("accepts a 2-letter alpha-2 `country` arg as CountryISO for legacy callers", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        country: "gb",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails.CountryISO).toBe("GB");
+    });
+
+    it("drops non-ISO `country` values rather than sending data the API will reject", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        country: "United Kingdom",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).not.toHaveProperty("CountryISO");
+    });
+
+    it("nests currency / termDays / VAT rate / nominal code inside a Preferences block", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        currency: "GBP",
+        termDays: 14,
+        defaultVatRate: 20,
+        defaultNominalCode: 5000,
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toHaveProperty("Preferences", {
+        DefaultCurrency: "GBP",
+        DefaultTerm: 14,
+        DefaultVatRate: 20,
+        DefaultNominalCode: 5000,
+      });
+      // Top-level Currency / TermDays would be rejected by the API.
+      expect(payload.SupplierDetails).not.toHaveProperty("Currency");
+      expect(payload.SupplierDetails).not.toHaveProperty("TermDays");
+    });
+
+    it("defaults Preferences.DefaultCurrency to GBP and DefaultTerm to 30 when neither was supplied", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails.Preferences).toEqual({
+        DefaultCurrency: "GBP",
+        DefaultTerm: 30,
+      });
+    });
+
+    it("passes companyNumber and supplierReference straight through", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        companyNumber: "01234567",
+        supplierReference: "ACME",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toMatchObject({
+        CompanyNumber: "01234567",
+        SupplierReference: "ACME",
+      });
+      // CompanyRegNo was the client-side name; suppliers want CompanyNumber.
+      expect(payload.SupplierDetails).not.toHaveProperty("CompanyRegNo");
+    });
+
+    it("returns the new SupplierID on success", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 9876 });
+
+      const result = await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toMatchObject({
+        success: true,
+        supplierId: 9876,
+      });
+    });
+  });
+
   describe("quickfile_supplier_update", () => {
     it("declares supplierId as a required input", () => {
       const tool = supplierTools.find(
@@ -42,6 +251,20 @@ describe("Supplier tools", () => {
       });
     });
 
+    it("does not expose the supplier-rejected args on update either", () => {
+      const tool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_update",
+      );
+      const props = (tool?.inputSchema as { properties: Record<string, unknown> })
+        .properties;
+
+      expect(props).not.toHaveProperty("title");
+      expect(props).not.toHaveProperty("mobile");
+      expect(props).not.toHaveProperty("notes");
+      expect(props).not.toHaveProperty("county");
+      expect(props).not.toHaveProperty("companyRegNo");
+    });
+
     it("wraps the payload in SupplierDetails (not SupplierData)", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
 
@@ -50,15 +273,13 @@ describe("Supplier tools", () => {
         email: "accounts@example.com",
       });
 
-      expect(mockRequest).toHaveBeenCalledWith("Supplier_Update", {
-        SupplierDetails: {
-          SupplierID: 12345,
-          ContactEmail: "accounts@example.com",
-        },
-      });
+      const [methodName, payload] = mockRequest.mock.calls[0];
+      expect(methodName).toBe("Supplier_Update");
+      expect(payload).toHaveProperty("SupplierDetails");
+      expect(payload).not.toHaveProperty("SupplierData");
     });
 
-    it("sends contact fields with the Contact-prefixed wire names", async () => {
+    it("emits Contact-prefixed contact fields with ContactSurName (CAPITAL N) and ContactTel", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
 
       await handleSupplierTool("quickfile_supplier_update", {
@@ -67,28 +288,64 @@ describe("Supplier tools", () => {
         lastName: "Lovelace",
         email: "ada@example.com",
         telephone: "020 7946 0000",
-        mobile: "07700 900123",
       });
 
       const [, payload] = mockRequest.mock.calls[0];
-      expect(payload.SupplierDetails).toEqual({
+      expect(payload.SupplierDetails).toMatchObject({
         SupplierID: 99,
         ContactFirstName: "Ada",
-        ContactSurname: "Lovelace",
+        ContactSurName: "Lovelace",
         ContactEmail: "ada@example.com",
-        ContactTelephone: "020 7946 0000",
-        ContactMobile: "07700 900123",
+        ContactTel: "020 7946 0000",
       });
-      // Negative assertions: the client-style bare field names must never appear
-      // — the Supplier_Update endpoint silently ignores them.
+      // Supplier_Update uses CAPITAL-N Surname; lowercase n is Create.
+      expect(payload.SupplierDetails).not.toHaveProperty("ContactSurname");
+      // Supplier_Update has no mobile field and rejects ContactTelephone.
+      expect(payload.SupplierDetails).not.toHaveProperty("ContactMobile");
+      expect(payload.SupplierDetails).not.toHaveProperty("ContactTelephone");
+      // Client-style bare names are rejected too.
       expect(payload.SupplierDetails).not.toHaveProperty("Email");
       expect(payload.SupplierDetails).not.toHaveProperty("FirstName");
-      expect(payload.SupplierDetails).not.toHaveProperty("Surname");
+      expect(payload.SupplierDetails).not.toHaveProperty("LastName");
       expect(payload.SupplierDetails).not.toHaveProperty("Telephone");
       expect(payload.SupplierDetails).not.toHaveProperty("Mobile");
     });
 
-    it("omits undefined fields so it acts as a true partial update", async () => {
+    it("emits flat address fields on update (no nested Address block)", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        address1: "76 Church Road",
+        town: "Market Drayton",
+        postcode: "TF9 4LA",
+        countryIso: "GB",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).toMatchObject({
+        SupplierID: 1,
+        AddressLine1: "76 Church Road",
+        Town: "Market Drayton",
+        Postcode: "TF9 4LA",
+        CountryISO: "GB",
+      });
+      expect(payload.SupplierDetails).not.toHaveProperty("Address");
+    });
+
+    it("omits Preferences entirely when no preference-related arg was supplied", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 1,
+        email: "x@example.com",
+      });
+
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SupplierDetails).not.toHaveProperty("Preferences");
+    });
+
+    it("acts as a true partial update — only supplied fields appear on the wire", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
 
       await handleSupplierTool("quickfile_supplier_update", {
@@ -97,7 +354,6 @@ describe("Supplier tools", () => {
       });
 
       const [, payload] = mockRequest.mock.calls[0];
-      // Only the two fields the caller supplied; nothing else creeps in.
       expect(Object.keys(payload.SupplierDetails).sort()).toEqual([
         "ContactEmail",
         "SupplierID",
@@ -123,30 +379,57 @@ describe("Supplier tools", () => {
       });
       expect(parsed).not.toHaveProperty("SupplierDetailsUpdated");
     });
+  });
 
-    it("includes the address block only when at least one address field is provided", async () => {
-      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+  describe("quickfile_supplier_search", () => {
+    it("sends the email filter as ContactEmail (not bare Email)", async () => {
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
 
-      await handleSupplierTool("quickfile_supplier_update", {
-        supplierId: 1,
-        postcode: "TF9 4LA",
+      await handleSupplierTool("quickfile_supplier_search", {
+        email: "accounts@example.com",
       });
 
-      const [, withAddress] = mockRequest.mock.calls[0];
-      expect(withAddress.SupplierDetails).toHaveProperty("Address", {
-        Postcode: "TF9 4LA",
+      const [methodName, payload] = mockRequest.mock.calls[0];
+      expect(methodName).toBe("Supplier_Search");
+      expect(payload.SearchParameters).toMatchObject({
+        ContactEmail: "accounts@example.com",
+      });
+      // Supplier_Search rejects bare Email — would silently return zero hits.
+      expect(payload.SearchParameters).not.toHaveProperty("Email");
+    });
+
+    it("splits the contact name filter into ContactFirstName and ContactSurname", async () => {
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
+
+      await handleSupplierTool("quickfile_supplier_search", {
+        firstName: "Ada",
+        lastName: "Lovelace",
       });
 
-      mockRequest.mockClear();
-      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: true });
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(payload.SearchParameters).toMatchObject({
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+      });
+      // ContactName was never a real wire field on either endpoint.
+      expect(payload.SearchParameters).not.toHaveProperty("ContactName");
+    });
 
-      await handleSupplierTool("quickfile_supplier_update", {
-        supplierId: 1,
-        email: "x@example.com",
+    it("omits undefined fields from SearchParameters", async () => {
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
+
+      await handleSupplierTool("quickfile_supplier_search", {
+        companyName: "Acme",
       });
 
-      const [, withoutAddress] = mockRequest.mock.calls[0];
-      expect(withoutAddress.SupplierDetails).not.toHaveProperty("Address");
+      const [, payload] = mockRequest.mock.calls[0];
+      expect(Object.keys(payload.SearchParameters).sort()).toEqual([
+        "CompanyName",
+        "Offset",
+        "OrderDirection",
+        "OrderResultsBy",
+        "ReturnCount",
+      ]);
     });
   });
 });


### PR DESCRIPTION
The supplier endpoints accept a noticeably different request shape from the client endpoints they look similar to. To map the differences, I checked the live API on 14 May 2026 by sending each endpoint a payload with a deliberately-wrong field name. QuickFile's 400 response listed every element it does accept, which let me piece the real shape together endpoint by endpoint.

Where the supplier endpoints diverge from the client ones:

| Concept            | Client endpoints              | Supplier endpoints                                 |
|--------------------|-------------------------------|----------------------------------------------------|
| Body wrapper       | ClientData                    | SupplierDetails                                    |
| Address fields     | Nested in an Address block    | Flat: AddressLine1/2/3, Town, Postcode, CountryISO |
| Defaults block     | Top-level Currency, TermDays  | Inside a Preferences block                         |
| Contact fields     | Bare: Email, FirstName, etc.  | Contact-prefixed (no mobile field at all)          |
| Surname casing     | LastName                      | Create: ContactSurname, Update: ContactSurName     |
| Args not valid     | n/a                           | Title, mobile, notes, county, companyRegNo         |
| Search email param | Email                         | ContactEmail                                       |

The surname casing actually differs between Supplier_Create (lowercase n) and Supplier_Update (capital N) — I double-checked because it looked like a typo on my end; QuickFile really is inconsistent here.

The Update-side split — separate buildClientUpdateData and buildSupplierUpdateData helpers, one per endpoint family — comes from the work originally in PR #79, now folded into this PR. That split made sense because the Update wire shape already differed between clients and suppliers. Create still shared a single buildEntityData on the working assumption that the two endpoints behaved the same. Now that we know Create diverges too, this PR mirrors the same approach on the Create side.

The concrete helper changes:

| Operation | Endpoint | Helper                  | Change                              |
|-----------|----------|-------------------------|-------------------------------------|
| Create    | Client   | buildClientCreateData   | Renamed from buildEntityData        |
| Create    | Supplier | buildSupplierCreateData | New; emits the verified wire shape  |
| Update    | Client   | buildClientUpdateData   | Unchanged                           |
| Update    | Supplier | buildSupplierUpdateData | Field names corrected               |

Plus:

- The supplier tool input schemas drop the args QuickFile doesn't accept (title, mobile, notes, county, companyRegNo)
- A comment block in utils.ts documents the verified wire shape so the next person working on this doesn't have to rediscover it

This PR replaces:

- #78 (the standalone Supplier_Search email-filter fix — the same fix is in here, with tests)
- #79 (which added supplier_update — that tool is here too, with the wire-shape corrections the live probes turned up)

Happy to break it back up if you'd prefer it split.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 307/307 passing
- [x] Live integration probes against the QuickFile API: Create + Update + Search all accepted with full field round-tripping via Supplier_Get

---

This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced supplier search with granular search parameters (firstName, lastName, email, postcode, and more).
  * Improved supplier create/update input schemas with clearer field requirements and optional parameters.

* **Tests**
  * Added comprehensive test suite for supplier tool operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->