### PR TITLE
GH#81: fix supplier API wire shape

### DIFF
--- a/src/tools/client.ts
+++ b/src/tools/client.ts
@@ -12,8 +12,8 @@ import {
   errorResult,
   cleanParams,
   buildAddressFromArgs,
-  buildEntityData,
-  buildEntityUpdateData,
+  buildClientCreateData,
+  buildClientUpdateData,
   searchSchemaProperties,
   entitySchemaProperties,
   type ToolResult,
@@ -227,7 +227,7 @@ export async function handleClientTool(
 
       case "quickfile_client_create": {
         const address = buildAddressFromArgs(args);
-        const clientData = buildEntityData(args, address);
+        const clientData = buildClientCreateData(args, address);
         const cleanData = cleanParams(clientData);
         const response = await apiClient.request<
           { ClientData: typeof cleanData },
@@ -243,7 +243,7 @@ export async function handleClientTool(
       case "quickfile_client_update": {
         const clientId = args.clientId as number;
         const address = buildAddressFromArgs(args);
-        const entityData = buildEntityUpdateData(args, address);
+        const entityData = buildClientUpdateData(args, address);
         const updateData = { ClientID: clientId, ...entityData };
         const cleanData = cleanParams(updateData);
         await apiClient.request<

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -264,13 +264,22 @@ async function handleSupplierDelete(
   });
 }
 
-const supplierHandlers = {
-  quickfile_supplier_search: handleSupplierSearch,
-  quickfile_supplier_get: handleSupplierGet,
-  quickfile_supplier_create: handleSupplierCreate,
-  quickfile_supplier_update: handleSupplierUpdate,
-  quickfile_supplier_delete: handleSupplierDelete,
-} as const;
+function getSupplierHandler(toolName: string) {
+  switch (toolName) {
+    case "quickfile_supplier_search":
+      return handleSupplierSearch;
+    case "quickfile_supplier_get":
+      return handleSupplierGet;
+    case "quickfile_supplier_create":
+      return handleSupplierCreate;
+    case "quickfile_supplier_update":
+      return handleSupplierUpdate;
+    case "quickfile_supplier_delete":
+      return handleSupplierDelete;
+    default:
+      return undefined;
+  }
+}
 
 // =============================================================================
 // Tool Handler
@@ -281,7 +290,7 @@ export async function handleSupplierTool(
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
   const apiClient = getApiClient();
-  const handler = supplierHandlers[toolName as keyof typeof supplierHandlers];
+  const handler = getSupplierHandler(toolName);
 
   if (!handler) {
     return errorResult(`Unknown supplier tool: ${toolName}`);

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -156,6 +156,122 @@ interface SupplierUpdateResponse {
   SupplierDetailsUpdated?: boolean;
 }
 
+interface QuickFileRequester {
+  request<TRequest, TResponse>(
+    methodName: string,
+    body: TRequest,
+  ): Promise<TResponse>;
+}
+
+function buildSupplierSearchParams(
+  args: Record<string, unknown>,
+): Partial<SupplierSearchParams> {
+  return cleanParams({
+    OrderResultsBy:
+      (args.orderBy as SupplierSearchParams["OrderResultsBy"]) ??
+      "CompanyName",
+    OrderDirection:
+      (args.orderDirection as SupplierSearchParams["OrderDirection"]) ?? "ASC",
+    ReturnCount: (args.returnCount as number) ?? 25,
+    Offset: (args.offset as number) ?? 0,
+    CompanyName: args.companyName as string | undefined,
+    ContactFirstName: args.firstName as string | undefined,
+    ContactSurname: args.lastName as string | undefined,
+    ContactEmail: args.email as string | undefined,
+    ContactTel: args.telephone as string | undefined,
+    SupplierReference: args.supplierReference as string | undefined,
+    Postcode: args.postcode as string | undefined,
+    ShowDeleted: args.showDeleted as boolean | undefined,
+  });
+}
+
+async function handleSupplierSearch(
+  apiClient: QuickFileRequester,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const cleaned = buildSupplierSearchParams(args);
+  const response = await apiClient.request<
+    { SearchParameters: typeof cleaned },
+    SupplierSearchResponse
+  >("Supplier_Search", { SearchParameters: cleaned });
+  const suppliers = response.Record || [];
+  return successResult({
+    totalRecords: response.RecordsetCount,
+    count: suppliers.length,
+    suppliers,
+  });
+}
+
+async function handleSupplierGet(
+  apiClient: QuickFileRequester,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const response = await apiClient.request<
+    { SupplierID: number },
+    SupplierGetResponse
+  >("Supplier_Get", { SupplierID: args.supplierId as number });
+  return successResult(response.SupplierDetails);
+}
+
+async function handleSupplierCreate(
+  apiClient: QuickFileRequester,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const supplierData = buildSupplierCreateData(args);
+  const cleanData = cleanParams(supplierData);
+  const response = await apiClient.request<
+    { SupplierDetails: typeof cleanData },
+    SupplierCreateResponse
+  >("Supplier_Create", { SupplierDetails: cleanData });
+  return successResult({
+    success: true,
+    supplierId: response.SupplierID,
+    message: `Supplier created successfully with ID ${response.SupplierID}`,
+  });
+}
+
+async function handleSupplierUpdate(
+  apiClient: QuickFileRequester,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const supplierId = args.supplierId as number;
+  const supplierData = buildSupplierUpdateData(args);
+  const updateData = { SupplierID: supplierId, ...supplierData };
+  const cleanData = cleanParams(updateData);
+  await apiClient.request<
+    { SupplierDetails: typeof cleanData },
+    SupplierUpdateResponse
+  >("Supplier_Update", { SupplierDetails: cleanData });
+  return successResult({
+    success: true,
+    supplierId,
+    message: `Supplier #${supplierId} updated successfully`,
+  });
+}
+
+async function handleSupplierDelete(
+  apiClient: QuickFileRequester,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  await apiClient.request<{ SupplierID: number }, Record<string, never>>(
+    "Supplier_Delete",
+    { SupplierID: args.supplierId as number },
+  );
+  return successResult({
+    success: true,
+    supplierId: args.supplierId,
+    message: `Supplier #${args.supplierId} deleted successfully`,
+  });
+}
+
+const supplierHandlers = {
+  quickfile_supplier_search: handleSupplierSearch,
+  quickfile_supplier_get: handleSupplierGet,
+  quickfile_supplier_create: handleSupplierCreate,
+  quickfile_supplier_update: handleSupplierUpdate,
+  quickfile_supplier_delete: handleSupplierDelete,
+} as const;
+
 // =============================================================================
 // Tool Handler
 // =============================================================================
@@ -165,94 +281,14 @@ export async function handleSupplierTool(
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
   const apiClient = getApiClient();
+  const handler = supplierHandlers[toolName as keyof typeof supplierHandlers];
+
+  if (!handler) {
+    return errorResult(`Unknown supplier tool: ${toolName}`);
+  }
 
   try {
-    switch (toolName) {
-      case "quickfile_supplier_search": {
-        const params: SupplierSearchParams = {
-          OrderResultsBy:
-            (args.orderBy as SupplierSearchParams["OrderResultsBy"]) ??
-            "CompanyName",
-          OrderDirection:
-            (args.orderDirection as SupplierSearchParams["OrderDirection"]) ??
-            "ASC",
-          ReturnCount: (args.returnCount as number) ?? 25,
-          Offset: (args.offset as number) ?? 0,
-          CompanyName: args.companyName as string | undefined,
-          ContactFirstName: args.firstName as string | undefined,
-          ContactSurname: args.lastName as string | undefined,
-          ContactEmail: args.email as string | undefined,
-          ContactTel: args.telephone as string | undefined,
-          SupplierReference: args.supplierReference as string | undefined,
-          Postcode: args.postcode as string | undefined,
-          ShowDeleted: args.showDeleted as boolean | undefined,
-        };
-        const cleaned = cleanParams(params);
-        const response = await apiClient.request<
-          { SearchParameters: typeof cleaned },
-          SupplierSearchResponse
-        >("Supplier_Search", { SearchParameters: cleaned });
-        const suppliers = response.Record || [];
-        return successResult({
-          totalRecords: response.RecordsetCount,
-          count: suppliers.length,
-          suppliers,
-        });
-      }
-
-      case "quickfile_supplier_get": {
-        const response = await apiClient.request<
-          { SupplierID: number },
-          SupplierGetResponse
-        >("Supplier_Get", { SupplierID: args.supplierId as number });
-        return successResult(response.SupplierDetails);
-      }
-
-      case "quickfile_supplier_create": {
-        const supplierData = buildSupplierCreateData(args);
-        const cleanData = cleanParams(supplierData);
-        const response = await apiClient.request<
-          { SupplierDetails: typeof cleanData },
-          SupplierCreateResponse
-        >("Supplier_Create", { SupplierDetails: cleanData });
-        return successResult({
-          success: true,
-          supplierId: response.SupplierID,
-          message: `Supplier created successfully with ID ${response.SupplierID}`,
-        });
-      }
-
-      case "quickfile_supplier_update": {
-        const supplierId = args.supplierId as number;
-        const supplierData = buildSupplierUpdateData(args);
-        const updateData = { SupplierID: supplierId, ...supplierData };
-        const cleanData = cleanParams(updateData);
-        await apiClient.request<
-          { SupplierDetails: typeof cleanData },
-          SupplierUpdateResponse
-        >("Supplier_Update", { SupplierDetails: cleanData });
-        return successResult({
-          success: true,
-          supplierId,
-          message: `Supplier #${supplierId} updated successfully`,
-        });
-      }
-
-      case "quickfile_supplier_delete": {
-        await apiClient.request<{ SupplierID: number }, Record<string, never>>(
-          "Supplier_Delete",
-          { SupplierID: args.supplierId as number },
-        );
-        return successResult({
-          success: true,
-          supplierId: args.supplierId,
-          message: `Supplier #${args.supplierId} deleted successfully`,
-        });
-      }
-
-      default:
-        return errorResult(`Unknown supplier tool: ${toolName}`);
-    }
+    return await handler(apiClient, args);
   } catch (error) {
     return handleToolError(error);
   }

--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -11,10 +11,9 @@ import {
   successResult,
   errorResult,
   cleanParams,
-  buildAddressFromArgs,
-  buildEntityData,
-  searchSchemaProperties,
-  entitySchemaProperties,
+  buildSupplierCreateData,
+  buildSupplierUpdateData,
+  supplierEntitySchemaProperties,
   type ToolResult,
 } from "./utils.js";
 
@@ -26,15 +25,61 @@ export const supplierTools: Tool[] = [
   {
     name: "quickfile_supplier_search",
     description:
-      "Search for suppliers by company name, contact name, email, or postcode. Response contains user-controlled fields (CompanyName, contact names) that are automatically sanitized.",
+      "Search for suppliers by company name, contact first/last name, contact email, telephone, supplier reference, or postcode. Response contains user-controlled fields that are automatically sanitized.",
     inputSchema: {
       type: "object",
       properties: {
-        ...searchSchemaProperties,
+        companyName: {
+          type: "string",
+          description: "Search by company name (partial match)",
+        },
+        firstName: {
+          type: "string",
+          description: "Search by contact first name",
+        },
+        lastName: {
+          type: "string",
+          description: "Search by contact surname",
+        },
+        email: {
+          type: "string",
+          description: "Search by contact email address",
+        },
+        telephone: {
+          type: "string",
+          description: "Search by contact telephone number",
+        },
+        supplierReference: {
+          type: "string",
+          description: "Search by supplier reference",
+        },
+        postcode: {
+          type: "string",
+          description: "Search by postcode",
+        },
+        showDeleted: {
+          type: "boolean",
+          description: "Include deleted suppliers in results",
+        },
+        returnCount: {
+          type: "number",
+          description: "Number of results (default: 25)",
+          default: 25,
+        },
+        offset: {
+          type: "number",
+          description: "Offset for pagination",
+          default: 0,
+        },
         orderBy: {
           type: "string",
           enum: ["CompanyName", "DateCreated", "SupplierID"],
           description: "Field to order by",
+        },
+        orderDirection: {
+          type: "string",
+          enum: ["ASC", "DESC"],
+          description: "Order direction",
         },
       },
       required: [],
@@ -57,8 +102,20 @@ export const supplierTools: Tool[] = [
     description: "Create a new supplier record",
     inputSchema: {
       type: "object",
-      properties: entitySchemaProperties,
-      required: [],
+      properties: supplierEntitySchemaProperties,
+      required: ["companyName"],
+    },
+  },
+  {
+    name: "quickfile_supplier_update",
+    description: "Update an existing supplier record",
+    inputSchema: {
+      type: "object",
+      properties: {
+        supplierId: { type: "number", description: "The supplier ID" },
+        ...supplierEntitySchemaProperties,
+      },
+      required: ["supplierId"],
     },
   },
   {
@@ -95,6 +152,10 @@ interface SupplierCreateResponse {
   SupplierID: number;
 }
 
+interface SupplierUpdateResponse {
+  SupplierDetailsUpdated?: boolean;
+}
+
 // =============================================================================
 // Tool Handler
 // =============================================================================
@@ -118,9 +179,13 @@ export async function handleSupplierTool(
           ReturnCount: (args.returnCount as number) ?? 25,
           Offset: (args.offset as number) ?? 0,
           CompanyName: args.companyName as string | undefined,
-          ContactName: args.contactName as string | undefined,
-          Email: args.email as string | undefined,
+          ContactFirstName: args.firstName as string | undefined,
+          ContactSurname: args.lastName as string | undefined,
+          ContactEmail: args.email as string | undefined,
+          ContactTel: args.telephone as string | undefined,
+          SupplierReference: args.supplierReference as string | undefined,
           Postcode: args.postcode as string | undefined,
+          ShowDeleted: args.showDeleted as boolean | undefined,
         };
         const cleaned = cleanParams(params);
         const response = await apiClient.request<
@@ -144,17 +209,32 @@ export async function handleSupplierTool(
       }
 
       case "quickfile_supplier_create": {
-        const address = buildAddressFromArgs(args);
-        const supplierData = buildEntityData(args, address);
+        const supplierData = buildSupplierCreateData(args);
         const cleanData = cleanParams(supplierData);
         const response = await apiClient.request<
-          { SupplierData: typeof cleanData },
+          { SupplierDetails: typeof cleanData },
           SupplierCreateResponse
-        >("Supplier_Create", { SupplierData: cleanData });
+        >("Supplier_Create", { SupplierDetails: cleanData });
         return successResult({
           success: true,
           supplierId: response.SupplierID,
           message: `Supplier created successfully with ID ${response.SupplierID}`,
+        });
+      }
+
+      case "quickfile_supplier_update": {
+        const supplierId = args.supplierId as number;
+        const supplierData = buildSupplierUpdateData(args);
+        const updateData = { SupplierID: supplierId, ...supplierData };
+        const cleanData = cleanParams(updateData);
+        await apiClient.request<
+          { SupplierDetails: typeof cleanData },
+          SupplierUpdateResponse
+        >("Supplier_Update", { SupplierDetails: cleanData });
+        return successResult({
+          success: true,
+          supplierId,
+          message: `Supplier #${supplierId} updated successfully`,
         });
       }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -666,22 +666,15 @@ export interface SupplierAddressFields {
 export function buildSupplierAddressFields(
   args: Record<string, unknown>,
 ): SupplierAddressFields {
-  const fields: SupplierAddressFields = {};
-  if (args.address1) {
-    fields.AddressLine1 = args.address1 as string;
-  }
-  if (args.address2) {
-    fields.AddressLine2 = args.address2 as string;
-  }
-  if (args.address3) {
-    fields.AddressLine3 = args.address3 as string;
-  }
-  if (args.town) {
-    fields.Town = args.town as string;
-  }
-  if (args.postcode) {
-    fields.Postcode = args.postcode as string;
-  }
+  const fields = Object.fromEntries(
+    [
+      ["AddressLine1", args.address1],
+      ["AddressLine2", args.address2],
+      ["AddressLine3", args.address3],
+      ["Town", args.town],
+      ["Postcode", args.postcode],
+    ].filter(([, value]) => value !== undefined),
+  ) as SupplierAddressFields;
 
   const rawCountry =
     typeof args.countryIso === "string"
@@ -707,19 +700,14 @@ export interface SupplierPreferences {
 function buildSupplierPreferences(
   args: Record<string, unknown>,
 ): SupplierPreferences | undefined {
-  const preferences: SupplierPreferences = {};
-  if (args.currency !== undefined) {
-    preferences.DefaultCurrency = args.currency as string;
-  }
-  if (args.termDays !== undefined) {
-    preferences.DefaultTerm = args.termDays as number;
-  }
-  if (args.defaultVatRate !== undefined) {
-    preferences.DefaultVatRate = args.defaultVatRate as number;
-  }
-  if (args.defaultNominalCode !== undefined) {
-    preferences.DefaultNominalCode = args.defaultNominalCode as number;
-  }
+  const preferences = Object.fromEntries(
+    [
+      ["DefaultCurrency", args.currency],
+      ["DefaultTerm", args.termDays],
+      ["DefaultVatRate", args.defaultVatRate],
+      ["DefaultNominalCode", args.defaultNominalCode],
+    ].filter(([, value]) => value !== undefined),
+  ) as SupplierPreferences;
   return Object.keys(preferences).length > 0 ? preferences : undefined;
 }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -454,8 +454,103 @@ export const entitySchemaProperties = {
   },
 };
 
+/**
+ * Supplier-specific properties for Supplier_Create / Supplier_Update.
+ * Supplier endpoints reject several client fields and use flat address fields,
+ * contact-prefixed names, and nested preferences on the wire.
+ */
+export const supplierEntitySchemaProperties = {
+  companyName: {
+    type: "string" as const,
+    description: "Company or organisation name",
+  },
+  companyNumber: {
+    type: "string" as const,
+    description: "Company registration number",
+  },
+  supplierReference: {
+    type: "string" as const,
+    description: "Free-form supplier reference",
+  },
+  firstName: {
+    type: "string" as const,
+    description: "Contact first name",
+  },
+  lastName: {
+    type: "string" as const,
+    description: "Contact last name",
+  },
+  email: {
+    type: "string" as const,
+    description: "Contact email address",
+  },
+  telephone: {
+    type: "string" as const,
+    description: "Contact telephone number",
+  },
+  website: {
+    type: "string" as const,
+    description: "Website URL",
+  },
+  address1: {
+    type: "string" as const,
+    description: "Address line 1",
+  },
+  address2: {
+    type: "string" as const,
+    description: "Address line 2",
+  },
+  address3: {
+    type: "string" as const,
+    description: "Address line 3",
+  },
+  town: {
+    type: "string" as const,
+    description: "Town/City",
+  },
+  postcode: {
+    type: "string" as const,
+    description: "Postcode",
+  },
+  countryIso: {
+    type: "string" as const,
+    description: "ISO 3166-1 alpha-2 country code (e.g. GB)",
+  },
+  country: {
+    type: "string" as const,
+    description:
+      "Deprecated alias for countryIso; must be an ISO alpha-2 country code",
+  },
+  vatNumber: {
+    type: "string" as const,
+    description: "VAT registration number",
+  },
+  vatExempt: {
+    type: "boolean" as const,
+    description: "Whether the supplier is VAT-exempt",
+  },
+  currency: {
+    type: "string" as const,
+    description: "Default currency (e.g. GBP)",
+    default: "GBP",
+  },
+  termDays: {
+    type: "number" as const,
+    description: "Default payment terms in days",
+    default: 30,
+  },
+  defaultVatRate: {
+    type: "number" as const,
+    description: "Default VAT rate",
+  },
+  defaultNominalCode: {
+    type: "number" as const,
+    description: "Default nominal code",
+  },
+};
+
 // =============================================================================
-// Shared Entity Builders (Client/Supplier)
+// Entity Builders (Client / Supplier)
 // =============================================================================
 
 /**
@@ -511,7 +606,7 @@ export function buildAddressFromArgs(
  * Extract common entity fields from tool arguments.
  * Shared mapping used by both create and update operations.
  */
-function extractEntityFields(
+function extractClientFields(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
@@ -537,13 +632,13 @@ function extractEntityFields(
  * Build entity data from tool arguments (for create operations).
  * Applies defaults for Currency and TermDays when not provided.
  */
-export function buildEntityData(
+export function buildClientCreateData(
   args: Record<string, unknown>,
   address: ClientAddress,
   defaults: { currency?: string; termDays?: number } = {},
 ): EntityData {
   const { currency = "GBP", termDays = 30 } = defaults;
-  const data = extractEntityFields(args, address);
+  const data = extractClientFields(args, address);
   data.Currency = data.Currency ?? currency;
   data.TermDays = data.TermDays ?? termDays;
   return data;
@@ -552,9 +647,141 @@ export function buildEntityData(
 /**
  * Build entity update data (preserves undefined for partial updates)
  */
-export function buildEntityUpdateData(
+export function buildClientUpdateData(
   args: Record<string, unknown>,
   address: ClientAddress,
 ): EntityData {
-  return extractEntityFields(args, address);
+  return extractClientFields(args, address);
+}
+
+export interface SupplierAddressFields {
+  AddressLine1?: string;
+  AddressLine2?: string;
+  AddressLine3?: string;
+  Town?: string;
+  Postcode?: string;
+  CountryISO?: string;
+}
+
+export function buildSupplierAddressFields(
+  args: Record<string, unknown>,
+): SupplierAddressFields {
+  const fields: SupplierAddressFields = {};
+  if (args.address1) {
+    fields.AddressLine1 = args.address1 as string;
+  }
+  if (args.address2) {
+    fields.AddressLine2 = args.address2 as string;
+  }
+  if (args.address3) {
+    fields.AddressLine3 = args.address3 as string;
+  }
+  if (args.town) {
+    fields.Town = args.town as string;
+  }
+  if (args.postcode) {
+    fields.Postcode = args.postcode as string;
+  }
+
+  const rawCountry =
+    typeof args.countryIso === "string"
+      ? args.countryIso
+      : typeof args.country === "string"
+        ? args.country
+        : undefined;
+  const country = rawCountry?.trim();
+  if (country && /^[A-Za-z]{2}$/.test(country)) {
+    fields.CountryISO = country.toUpperCase();
+  }
+
+  return fields;
+}
+
+export interface SupplierPreferences {
+  DefaultCurrency?: string;
+  DefaultTerm?: number;
+  DefaultVatRate?: number;
+  DefaultNominalCode?: number;
+}
+
+function buildSupplierPreferences(
+  args: Record<string, unknown>,
+): SupplierPreferences | undefined {
+  const preferences: SupplierPreferences = {};
+  if (args.currency !== undefined) {
+    preferences.DefaultCurrency = args.currency as string;
+  }
+  if (args.termDays !== undefined) {
+    preferences.DefaultTerm = args.termDays as number;
+  }
+  if (args.defaultVatRate !== undefined) {
+    preferences.DefaultVatRate = args.defaultVatRate as number;
+  }
+  if (args.defaultNominalCode !== undefined) {
+    preferences.DefaultNominalCode = args.defaultNominalCode as number;
+  }
+  return Object.keys(preferences).length > 0 ? preferences : undefined;
+}
+
+interface SupplierBaseData extends SupplierAddressFields {
+  CompanyName?: string;
+  CompanyNumber?: string;
+  SupplierReference?: string;
+  ContactFirstName?: string;
+  ContactTel?: string;
+  ContactEmail?: string;
+  Website?: string;
+  VatNumber?: string;
+  VatExempt?: boolean;
+  Preferences?: SupplierPreferences;
+}
+
+export interface SupplierCreateData extends SupplierBaseData {
+  ContactSurname?: string;
+}
+
+export interface SupplierUpdateData extends SupplierBaseData {
+  ContactSurName?: string;
+}
+
+function buildSupplierBaseData(args: Record<string, unknown>): SupplierBaseData {
+  return {
+    CompanyName: args.companyName as string | undefined,
+    CompanyNumber: args.companyNumber as string | undefined,
+    SupplierReference: args.supplierReference as string | undefined,
+    ContactFirstName: args.firstName as string | undefined,
+    ContactTel: args.telephone as string | undefined,
+    ContactEmail: args.email as string | undefined,
+    Website: args.website as string | undefined,
+    VatNumber: args.vatNumber as string | undefined,
+    VatExempt: args.vatExempt as boolean | undefined,
+    Preferences: buildSupplierPreferences(args),
+    ...buildSupplierAddressFields(args),
+  };
+}
+
+export function buildSupplierCreateData(
+  args: Record<string, unknown>,
+  defaults: { currency?: string; termDays?: number } = {},
+): SupplierCreateData {
+  const { currency = "GBP", termDays = 30 } = defaults;
+  const data = buildSupplierBaseData({
+    ...args,
+    currency: args.currency ?? currency,
+    termDays: args.termDays ?? termDays,
+  });
+  return {
+    ...data,
+    ContactSurname: args.lastName as string | undefined,
+  };
+}
+
+export function buildSupplierUpdateData(
+  args: Record<string, unknown>,
+): SupplierUpdateData {
+  const data = buildSupplierBaseData(args);
+  return {
+    ...data,
+    ContactSurName: args.lastName as string | undefined,
+  };
 }

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -319,9 +319,13 @@ export interface Supplier {
 
 export interface SupplierSearchParams {
   CompanyName?: string;
-  ContactName?: string;
-  Email?: string;
+  ContactFirstName?: string;
+  ContactSurname?: string;
+  ContactEmail?: string;
+  ContactTel?: string;
+  SupplierReference?: string;
   Postcode?: string;
+  ShowDeleted?: boolean;
   ReturnCount?: number;
   Offset?: number;
   OrderResultsBy?: 'CompanyName' | 'DateCreated' | 'SupplierID';

--- a/tests/unit/client-tools.test.ts
+++ b/tests/unit/client-tools.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for client tool wire shapes.
+ */
+
+import { handleClientTool } from "../../src/tools/client";
+import { getApiClient } from "../../src/api/client";
+
+jest.mock("../../src/api/client", () => ({
+  getApiClient: jest.fn(),
+  QuickFileApiError: class QuickFileApiError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = "QuickFileApiError";
+    }
+  },
+}));
+
+describe("Client tools", () => {
+  const mockRequest = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiClient as jest.Mock).mockReturnValue({ request: mockRequest });
+  });
+
+  it("keeps client create on ClientData with nested Address and flat defaults", async () => {
+    mockRequest.mockResolvedValueOnce({ ClientID: 123 });
+
+    await handleClientTool("quickfile_client_create", {
+      companyName: "Acme Widgets Ltd",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: "ada@example.com",
+      address1: "1 Example Street",
+      town: "Market Drayton",
+      country: "United Kingdom",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith("Client_Create", {
+      ClientData: expect.objectContaining({
+        CompanyName: "Acme Widgets Ltd",
+        FirstName: "Ada",
+        LastName: "Lovelace",
+        Email: "ada@example.com",
+        Currency: "GBP",
+        TermDays: 30,
+        Address: {
+          Address1: "1 Example Street",
+          Town: "Market Drayton",
+          Country: "United Kingdom",
+        },
+      }),
+    });
+  });
+
+  it("keeps client update as a partial ClientData payload", async () => {
+    mockRequest.mockResolvedValueOnce({});
+
+    await handleClientTool("quickfile_client_update", {
+      clientId: 456,
+      email: "new@example.com",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith("Client_Update", {
+      ClientData: {
+        ClientID: 456,
+        Email: "new@example.com",
+      },
+    });
+  });
+});

--- a/tests/unit/client-tools.test.ts
+++ b/tests/unit/client-tools.test.ts
@@ -39,20 +39,23 @@ describe("Client tools", () => {
       country: "United Kingdom",
     });
 
-    expect(mockRequest).toHaveBeenCalledWith("Client_Create", {
-      ClientData: expect.objectContaining({
-        CompanyName: "Acme Widgets Ltd",
-        FirstName: "Ada",
-        LastName: "Lovelace",
-        Email: "ada@example.com",
-        Currency: "GBP",
-        TermDays: 30,
-        Address: {
-          Address1: "1 Example Street",
-          Town: "Market Drayton",
-          Country: "United Kingdom",
-        },
-      }),
+    const payload = mockRequest.mock.calls[0][1];
+    expect(mockRequest).toHaveBeenCalledWith(
+      "Client_Create",
+      expect.any(Object),
+    );
+    expect(payload.ClientData).toMatchObject({
+      CompanyName: "Acme Widgets Ltd",
+      FirstName: "Ada",
+      LastName: "Lovelace",
+      Email: "ada@example.com",
+      Currency: "GBP",
+      TermDays: 30,
+    });
+    expect(payload.ClientData.Address).toEqual({
+      Address1: "1 Example Street",
+      Town: "Market Drayton",
+      Country: "United Kingdom",
     });
   });
 

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -100,30 +100,34 @@ describe("Supplier tools", () => {
         defaultNominalCode: 5000,
       });
 
-      expect(mockRequest).toHaveBeenCalledWith("Supplier_Create", {
-        SupplierDetails: expect.objectContaining({
-          CompanyName: "Acme Widgets Ltd",
-          CompanyNumber: "01234567",
-          SupplierReference: "ACME",
-          ContactFirstName: "Ada",
-          ContactSurname: "Lovelace",
-          ContactEmail: "ada@example.com",
-          ContactTel: "020 7946 0000",
-          AddressLine1: "1 Example Street",
-          AddressLine2: "Industrial Estate",
-          AddressLine3: "Greater Trading Park",
-          Town: "Market Drayton",
-          Postcode: "TF9 4LA",
-          CountryISO: "GB",
-          Preferences: {
-            DefaultCurrency: "GBP",
-            DefaultTerm: 30,
-            DefaultVatRate: 20,
-            DefaultNominalCode: 5000,
-          },
-        }),
-      });
+      expect(mockRequest).toHaveBeenCalledWith(
+        "Supplier_Create",
+        expect.any(Object),
+      );
       const details = lastPayload().SupplierDetails;
+      expect(details).toMatchObject({
+        CompanyName: "Acme Widgets Ltd",
+        CompanyNumber: "01234567",
+        SupplierReference: "ACME",
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+        ContactEmail: "ada@example.com",
+        ContactTel: "020 7946 0000",
+      });
+      expect(details).toMatchObject({
+        AddressLine1: "1 Example Street",
+        AddressLine2: "Industrial Estate",
+        AddressLine3: "Greater Trading Park",
+        Town: "Market Drayton",
+        Postcode: "TF9 4LA",
+        CountryISO: "GB",
+      });
+      expect(details.Preferences).toEqual({
+        DefaultCurrency: "GBP",
+        DefaultTerm: 30,
+        DefaultVatRate: 20,
+        DefaultNominalCode: 5000,
+      });
       expect(details).not.toHaveProperty("SupplierData");
       expect(details).not.toHaveProperty("Address");
       expect(details).not.toHaveProperty("ContactSurName");

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -79,7 +79,7 @@ describe("Supplier tools", () => {
       }
     });
 
-    it("wraps SupplierDetails with contact, address, country, and preference fields", async () => {
+    it("wraps SupplierDetails with supplier identity and contact fields", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
 
       await handleSupplierTool("quickfile_supplier_create", {
@@ -90,14 +90,6 @@ describe("Supplier tools", () => {
         lastName: "Lovelace",
         email: "ada@example.com",
         telephone: "020 7946 0000",
-        address1: "1 Example Street",
-        address2: "Industrial Estate",
-        address3: "Greater Trading Park",
-        town: "Market Drayton",
-        postcode: "TF9 4LA",
-        countryIso: "gb",
-        defaultVatRate: 20,
-        defaultNominalCode: 5000,
       });
 
       expect(mockRequest).toHaveBeenCalledWith(
@@ -114,6 +106,31 @@ describe("Supplier tools", () => {
         ContactEmail: "ada@example.com",
         ContactTel: "020 7946 0000",
       });
+      expect(details).not.toHaveProperty("SupplierData");
+      expect(details).not.toHaveProperty("ContactSurName");
+      expect(details).not.toHaveProperty("Email");
+    });
+
+    it("wraps SupplierDetails with flat address and preference fields", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        address1: "1 Example Street",
+        address2: "Industrial Estate",
+        address3: "Greater Trading Park",
+        town: "Market Drayton",
+        postcode: "TF9 4LA",
+        countryIso: "gb",
+        defaultVatRate: 20,
+        defaultNominalCode: 5000,
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        "Supplier_Create",
+        expect.any(Object),
+      );
+      const details = lastPayload().SupplierDetails;
       expect(details).toMatchObject({
         AddressLine1: "1 Example Street",
         AddressLine2: "Industrial Estate",
@@ -130,10 +147,8 @@ describe("Supplier tools", () => {
       });
       expect(details).not.toHaveProperty("SupplierData");
       expect(details).not.toHaveProperty("Address");
-      expect(details).not.toHaveProperty("ContactSurName");
       expect(details).not.toHaveProperty("Currency");
       expect(details).not.toHaveProperty("TermDays");
-      expect(details).not.toHaveProperty("Email");
     });
 
     it("accepts legacy country only when it is a two-letter ISO code", async () => {

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for supplier tools.
+ */
+
+import { handleSupplierTool, supplierTools } from "../../src/tools/supplier";
+import { getApiClient } from "../../src/api/client";
+
+jest.mock("../../src/api/client", () => ({
+  getApiClient: jest.fn(),
+  QuickFileApiError: class QuickFileApiError extends Error {
+    constructor(
+      message: string,
+      public code: string,
+    ) {
+      super(message);
+      this.name = "QuickFileApiError";
+    }
+  },
+}));
+
+type ToolPayload = Record<string, Record<string, unknown>>;
+
+describe("Supplier tools", () => {
+  const mockRequest = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getApiClient as jest.Mock).mockReturnValue({ request: mockRequest });
+  });
+
+  function propertiesFor(toolName: string): Record<string, unknown> {
+    const tool = supplierTools.find((candidate) => candidate.name === toolName);
+    return (tool?.inputSchema as { properties: Record<string, unknown> })
+      .properties;
+  }
+
+  function lastPayload(): ToolPayload {
+    return mockRequest.mock.calls[0][1] as ToolPayload;
+  }
+
+  describe("quickfile_supplier_search", () => {
+    it("exposes supplier-specific filters and sends supplier wire names", async () => {
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: [] });
+
+      await handleSupplierTool("quickfile_supplier_search", {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "accounts@example.com",
+        telephone: "020 7946 0000",
+        supplierReference: "ACME",
+      });
+
+      expect(propertiesFor("quickfile_supplier_search")).toMatchObject({
+        telephone: { type: "string" },
+        supplierReference: { type: "string" },
+      });
+      expect(lastPayload().SearchParameters).toMatchObject({
+        ContactFirstName: "Ada",
+        ContactSurname: "Lovelace",
+        ContactEmail: "accounts@example.com",
+        ContactTel: "020 7946 0000",
+        SupplierReference: "ACME",
+      });
+      expect(lastPayload().SearchParameters).not.toHaveProperty("Email");
+      expect(lastPayload().SearchParameters).not.toHaveProperty("ContactName");
+    });
+  });
+
+  describe("quickfile_supplier_create", () => {
+    it("requires companyName and omits client-only supplier-rejected fields", () => {
+      const createTool = supplierTools.find(
+        (candidate) => candidate.name === "quickfile_supplier_create",
+      );
+      const props = propertiesFor("quickfile_supplier_create");
+
+      expect(createTool?.inputSchema).toMatchObject({ required: ["companyName"] });
+      for (const rejected of ["title", "mobile", "notes", "county", "companyRegNo"]) {
+        expect(props).not.toHaveProperty(rejected);
+      }
+    });
+
+    it("wraps SupplierDetails with contact, address, country, and preference fields", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 12345 });
+
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme Widgets Ltd",
+        companyNumber: "01234567",
+        supplierReference: "ACME",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        email: "ada@example.com",
+        telephone: "020 7946 0000",
+        address1: "1 Example Street",
+        address2: "Industrial Estate",
+        address3: "Greater Trading Park",
+        town: "Market Drayton",
+        postcode: "TF9 4LA",
+        countryIso: "gb",
+        defaultVatRate: 20,
+        defaultNominalCode: 5000,
+      });
+
+      expect(mockRequest).toHaveBeenCalledWith("Supplier_Create", {
+        SupplierDetails: expect.objectContaining({
+          CompanyName: "Acme Widgets Ltd",
+          CompanyNumber: "01234567",
+          SupplierReference: "ACME",
+          ContactFirstName: "Ada",
+          ContactSurname: "Lovelace",
+          ContactEmail: "ada@example.com",
+          ContactTel: "020 7946 0000",
+          AddressLine1: "1 Example Street",
+          AddressLine2: "Industrial Estate",
+          AddressLine3: "Greater Trading Park",
+          Town: "Market Drayton",
+          Postcode: "TF9 4LA",
+          CountryISO: "GB",
+          Preferences: {
+            DefaultCurrency: "GBP",
+            DefaultTerm: 30,
+            DefaultVatRate: 20,
+            DefaultNominalCode: 5000,
+          },
+        }),
+      });
+      const details = lastPayload().SupplierDetails;
+      expect(details).not.toHaveProperty("SupplierData");
+      expect(details).not.toHaveProperty("Address");
+      expect(details).not.toHaveProperty("ContactSurName");
+      expect(details).not.toHaveProperty("Currency");
+      expect(details).not.toHaveProperty("TermDays");
+      expect(details).not.toHaveProperty("Email");
+    });
+
+    it("accepts legacy country only when it is a two-letter ISO code", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme",
+        country: "United Kingdom",
+      });
+      expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+
+      mockRequest.mockClear();
+      mockRequest.mockResolvedValueOnce({ SupplierID: 2 });
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme",
+        country: "gb",
+      });
+      expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
+    });
+  });
+
+  describe("quickfile_supplier_update", () => {
+    it("declares supplierId as required and sends true partial updates", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 42,
+        email: "x@example.com",
+      });
+
+      expect(supplierTools.find((tool) => tool.name === "quickfile_supplier_update")?.inputSchema).toMatchObject({
+        required: ["supplierId"],
+      });
+      expect(mockRequest).toHaveBeenCalledWith("Supplier_Update", {
+        SupplierDetails: {
+          SupplierID: 42,
+          ContactEmail: "x@example.com",
+        },
+      });
+    });
+
+    it("uses Supplier_Update surname casing and omits misleading API flag", async () => {
+      mockRequest.mockResolvedValueOnce({ SupplierDetailsUpdated: false });
+
+      const result = await handleSupplierTool("quickfile_supplier_update", {
+        supplierId: 7,
+        lastName: "Lovelace",
+      });
+
+      expect(lastPayload().SupplierDetails).toMatchObject({
+        SupplierID: 7,
+        ContactSurName: "Lovelace",
+      });
+      expect(lastPayload().SupplierDetails).not.toHaveProperty("ContactSurname");
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        supplierId: 7,
+        message: "Supplier #7 updated successfully",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implemented supplier-specific search/create/update payload builders so supplier endpoints use SupplierDetails, contact-prefixed fields, flat address fields, normalized CountryISO, and nested Preferences while client tools keep their existing ClientData shape.

## Files Changed

src/tools/client.ts,src/tools/supplier.ts,src/tools/utils.ts,src/types/quickfile.ts,tests/unit/client-tools.test.ts,tests/unit/supplier.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run build; npm run lint; npm test

Resolves #81


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with gpt-5.5 spent 46m and 157,656 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced supplier search with additional filter options: contact first name, surname, email, phone, reference, and visibility of deleted records.

* **Improvements**
  * Refined supplier and client data processing for more accurate field handling.

* **Tests**
  * Added comprehensive test coverage for client and supplier tool operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/82)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->