### PR TITLE
GH#83: harden supplier response handling

### DIFF
--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -194,7 +194,8 @@ async function handleSupplierSearch(
     { SearchParameters: typeof cleaned },
     SupplierSearchResponse
   >("Supplier_Search", { SearchParameters: cleaned });
-  const suppliers = response.Record || [];
+  const record = response.Record as Supplier | Supplier[] | undefined;
+  const suppliers = Array.isArray(record) ? record : record ? [record] : [];
   return successResult({
     totalRecords: response.RecordsetCount,
     count: suppliers.length,
@@ -289,7 +290,6 @@ export async function handleSupplierTool(
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
-  const apiClient = getApiClient();
   const handler = getSupplierHandler(toolName);
 
   if (!handler) {
@@ -297,6 +297,7 @@ export async function handleSupplierTool(
   }
 
   try {
+    const apiClient = getApiClient();
     return await handler(apiClient, args);
   } catch (error) {
     return handleToolError(error);

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -5,6 +5,13 @@
 
 import { QuickFileApiError } from "../api/client.js";
 import { sanitizeOutput } from "../sanitize.js";
+import type {
+  SupplierAddressFields,
+  SupplierBaseData,
+  SupplierCreateData,
+  SupplierPreferences,
+  SupplierUpdateData,
+} from "../types/quickfile.js";
 
 // Re-export validation helpers and schemas
 export { validateArgs, validateArgsSafe } from "./schemas.js";
@@ -654,14 +661,20 @@ export function buildClientUpdateData(
   return extractClientFields(args, address);
 }
 
-export interface SupplierAddressFields {
-  AddressLine1?: string;
-  AddressLine2?: string;
-  AddressLine3?: string;
-  Town?: string;
-  Postcode?: string;
-  CountryISO?: string;
-}
+const VALID_ISO_ALPHA2_CODES = new Set([
+  "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX", "AZ",
+  "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ",
+  "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CR", "CU", "CV", "CW", "CX", "CY", "CZ",
+  "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR",
+  "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT", "GU", "GW", "GY",
+  "HK", "HM", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT",
+  "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY",
+  "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ",
+  "NA", "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY",
+  "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SV", "SX", "SY", "SZ",
+  "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI", "VN", "VU",
+  "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW",
+]);
 
 export function buildSupplierAddressFields(
   args: Record<string, unknown>,
@@ -676,25 +689,19 @@ export function buildSupplierAddressFields(
     ].filter(([, value]) => value !== undefined),
   ) as SupplierAddressFields;
 
-  const rawCountry =
-    typeof args.countryIso === "string"
-      ? args.countryIso
-      : typeof args.country === "string"
-        ? args.country
-        : undefined;
-  const country = rawCountry?.trim();
-  if (country && /^[A-Za-z]{2}$/.test(country)) {
-    fields.CountryISO = country.toUpperCase();
+  let rawCountry: string | undefined;
+  if (typeof args.countryIso === "string") {
+    rawCountry = args.countryIso;
+  } else if (typeof args.country === "string") {
+    rawCountry = args.country;
+  }
+
+  const country = rawCountry?.trim().toUpperCase();
+  if (country && VALID_ISO_ALPHA2_CODES.has(country)) {
+    fields.CountryISO = country;
   }
 
   return fields;
-}
-
-export interface SupplierPreferences {
-  DefaultCurrency?: string;
-  DefaultTerm?: number;
-  DefaultVatRate?: number;
-  DefaultNominalCode?: number;
 }
 
 function buildSupplierPreferences(
@@ -709,27 +716,6 @@ function buildSupplierPreferences(
     ].filter(([, value]) => value !== undefined),
   ) as SupplierPreferences;
   return Object.keys(preferences).length > 0 ? preferences : undefined;
-}
-
-interface SupplierBaseData extends SupplierAddressFields {
-  CompanyName?: string;
-  CompanyNumber?: string;
-  SupplierReference?: string;
-  ContactFirstName?: string;
-  ContactTel?: string;
-  ContactEmail?: string;
-  Website?: string;
-  VatNumber?: string;
-  VatExempt?: boolean;
-  Preferences?: SupplierPreferences;
-}
-
-export interface SupplierCreateData extends SupplierBaseData {
-  ContactSurname?: string;
-}
-
-export interface SupplierUpdateData extends SupplierBaseData {
-  ContactSurName?: string;
 }
 
 function buildSupplierBaseData(args: Record<string, unknown>): SupplierBaseData {

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -332,6 +332,43 @@ export interface SupplierSearchParams {
   OrderDirection?: 'ASC' | 'DESC';
 }
 
+export interface SupplierAddressFields {
+  AddressLine1?: string;
+  AddressLine2?: string;
+  AddressLine3?: string;
+  Town?: string;
+  Postcode?: string;
+  CountryISO?: string;
+}
+
+export interface SupplierPreferences {
+  DefaultCurrency?: string;
+  DefaultTerm?: number;
+  DefaultVatRate?: number;
+  DefaultNominalCode?: number;
+}
+
+export interface SupplierBaseData extends SupplierAddressFields {
+  CompanyName?: string;
+  CompanyNumber?: string;
+  SupplierReference?: string;
+  ContactFirstName?: string;
+  ContactTel?: string;
+  ContactEmail?: string;
+  Website?: string;
+  VatNumber?: string;
+  VatExempt?: boolean;
+  Preferences?: SupplierPreferences;
+}
+
+export interface SupplierCreateData extends SupplierBaseData {
+  ContactSurname?: string;
+}
+
+export interface SupplierUpdateData extends SupplierBaseData {
+  ContactSurName?: string;
+}
+
 // =============================================================================
 // Bank Types
 // =============================================================================

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -64,6 +64,21 @@ describe("Supplier tools", () => {
       expect(lastPayload().SearchParameters).not.toHaveProperty("Email");
       expect(lastPayload().SearchParameters).not.toHaveProperty("ContactName");
     });
+
+    it("normalizes a single Supplier_Search record into the suppliers array", async () => {
+      mockRequest.mockResolvedValueOnce({
+        RecordsetCount: 1,
+        Record: { SupplierID: 42, CompanyName: "Solo Supplier" },
+      });
+
+      const result = await handleSupplierTool("quickfile_supplier_search", {});
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        totalRecords: 1,
+        count: 1,
+        suppliers: [{ SupplierID: 42, CompanyName: "Solo Supplier" }],
+      });
+    });
   });
 
   describe("quickfile_supplier_create", () => {
@@ -151,7 +166,7 @@ describe("Supplier tools", () => {
       expect(details).not.toHaveProperty("TermDays");
     });
 
-    it("accepts legacy country only when it is a two-letter ISO code", async () => {
+    it("accepts legacy country only when it is a valid two-letter ISO code", async () => {
       mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
       await handleSupplierTool("quickfile_supplier_create", {
         companyName: "Acme",
@@ -166,6 +181,44 @@ describe("Supplier tools", () => {
         country: "gb",
       });
       expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
+
+      mockRequest.mockClear();
+      mockRequest.mockResolvedValueOnce({ SupplierID: 3 });
+      await handleSupplierTool("quickfile_supplier_create", {
+        companyName: "Acme",
+        countryIso: "ZZ",
+      });
+      expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+    });
+  });
+
+  describe("handleSupplierTool", () => {
+    it("wraps getApiClient errors with the standard tool error result", async () => {
+      (getApiClient as jest.Mock).mockImplementationOnce(() => {
+        throw new Error("missing credentials");
+      });
+
+      const result = await handleSupplierTool("quickfile_supplier_search", {});
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Error: missing credentials" }],
+        isError: true,
+      });
+    });
+
+    it("does not initialize the API client for unknown supplier tools", async () => {
+      const result = await handleSupplierTool("quickfile_supplier_unknown", {});
+
+      expect(getApiClient).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Unknown supplier tool: quickfile_supplier_unknown",
+          },
+        ],
+        isError: true,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Normalize single-record `Supplier_Search.Record` responses before deriving `count`.
- Move supplier request wire types into `src/types/quickfile.ts` and keep tool builders in `src/tools/utils.ts`.
- Validate supplier `CountryISO` against ISO 3166-1 alpha-2 codes and handle API client initialization through the standard tool error wrapper.

## Testing
- `npm test -- --runTestsByPath tests/unit/supplier.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`

Resolves #83

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 4m and 72,284 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed supplier search to properly handle single-record API responses and normalize them consistently.
  * Improved error handling in supplier tool execution to catch and report API initialization failures appropriately.

* **Enhancements**
  * Strengthened country code validation to accept only valid ISO-3166-1 alpha-2 codes (e.g., "US", "GB").

* **Tests**
  * Added unit test coverage for single-record supplier search responses and country code validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->