### PR TITLE
fix: align supplier search response type

### DIFF
--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -141,7 +141,7 @@ export const supplierTools: Tool[] = [
 interface SupplierSearchResponse {
   RecordsetCount: number;
   ReturnCount: number;
-  Record: Supplier[];
+  Record?: Supplier | Supplier[];
 }
 
 interface SupplierGetResponse {
@@ -194,7 +194,7 @@ async function handleSupplierSearch(
     { SearchParameters: typeof cleaned },
     SupplierSearchResponse
   >("Supplier_Search", { SearchParameters: cleaned });
-  const record = response.Record as Supplier | Supplier[] | undefined;
+  const record = response.Record;
   const suppliers = Array.isArray(record) ? record : record ? [record] : [];
   return successResult({
     totalRecords: response.RecordsetCount,


### PR DESCRIPTION
## Summary
- Models `SupplierSearchResponse.Record` as optional and as either a single `Supplier` or `Supplier[]` to match the QuickFile wire format.
- Removes the manual cast in supplier search normalization.

## Testing
- `npm test -- --runInBand tests/unit/supplier.test.ts`
- `npm run typecheck`

MERGE_SUMMARY
Implemented issue #85 by updating `src/tools/supplier.ts` so `Supplier_Search` response typing reflects absent, singleton, and array `Record` payloads. Verification passed with targeted unit tests and TypeScript type checking.

Resolves #85

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 4m and 51,154 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved supplier search response handling to better accommodate various data conditions. The system now gracefully manages cases where supplier records may be absent or structured differently, enhancing the reliability of supplier search operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->