### PR TITLE
Refactor supplier country selection

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -689,12 +689,12 @@ export function buildSupplierAddressFields(
     ].filter(([, value]) => value !== undefined),
   ) as SupplierAddressFields;
 
-  let rawCountry: string | undefined;
-  if (typeof args.countryIso === "string") {
-    rawCountry = args.countryIso;
-  } else if (typeof args.country === "string") {
-    rawCountry = args.country;
-  }
+  const rawCountry =
+    typeof args.countryIso === "string"
+      ? args.countryIso
+      : typeof args.country === "string"
+        ? args.country
+        : undefined;
 
   const country = rawCountry?.trim().toUpperCase();
   if (country && VALID_ISO_ALPHA2_CODES.has(country)) {


### PR DESCRIPTION
## Summary
- Simplifies supplier country input selection to use a `const` ternary while preserving `countryIso` precedence and validation behavior.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

Resolves #86

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with gpt-5.5 spent 3m and 73,372 tokens on this as a headless worker.
