### PR TITLE
fix: centralize supplier search response type

### DIFF
--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -5,7 +5,11 @@
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { getApiClient } from "../api/client.js";
-import type { Supplier, SupplierSearchParams } from "../types/quickfile.js";
+import type {
+  Supplier,
+  SupplierSearchParams,
+  SupplierSearchResponse,
+} from "../types/quickfile.js";
 import {
   handleToolError,
   successResult,
@@ -137,12 +141,6 @@ export const supplierTools: Tool[] = [
 // =============================================================================
 // Tool Handlers
 // =============================================================================
-
-interface SupplierSearchResponse {
-  RecordsetCount: number;
-  ReturnCount: number;
-  Record?: Supplier | Supplier[];
-}
 
 interface SupplierGetResponse {
   SupplierDetails: Supplier;

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -332,6 +332,12 @@ export interface SupplierSearchParams {
   OrderDirection?: 'ASC' | 'DESC';
 }
 
+export interface SupplierSearchResponse {
+  RecordsetCount: number;
+  ReturnCount: number;
+  Record?: Supplier | Supplier[] | null;
+}
+
 export interface SupplierAddressFields {
   AddressLine1?: string;
   AddressLine2?: string;


### PR DESCRIPTION
## Summary
- Moves SupplierSearchResponse into src/types/quickfile.ts to keep QuickFile API response contracts in the shared types boundary.
- Allows Supplier_Search Record to be null as well as a single supplier, an array, or absent.

## Testing
- npm run typecheck
- npm run lint
- npm test

Resolves #89

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 3m and 58,225 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and type management through better module structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->