### PR TITLE
GH#90: docs: clarify supplier country validation

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -697,6 +697,8 @@ export function buildSupplierAddressFields(
         : undefined;
 
   const country = rawCountry?.trim().toUpperCase();
+  // QuickFile expects ISO-3166-1 alpha-2 values; ignore unrecognised input
+  // instead of throwing so supplier creation can still use other valid fields.
   if (country && VALID_ISO_ALPHA2_CODES.has(country)) {
     fields.CountryISO = country;
   }


### PR DESCRIPTION
## Summary

Verified the supplier search response and country normalization review followups. The Gemini suggestions were already reflected in current code; added a targeted comment documenting why invalid supplier country codes are ignored instead of throwing.

## Files Changed

src/tools/utils.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint; npm run typecheck; npm test -- --runInBand tests/unit/supplier.test.ts tests/unit/utils.test.ts

Resolves #90


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with gpt-5.5 spent 4m and 55,964 tokens on this as a headless worker.