### PR TITLE
GH#93: test: cover null supplier search records

### DIFF
--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -79,6 +79,18 @@ describe("Supplier tools", () => {
         suppliers: [{ SupplierID: 42, CompanyName: "Solo Supplier" }],
       });
     });
+
+    it("normalizes a null Supplier_Search record into an empty suppliers array", async () => {
+      mockRequest.mockResolvedValueOnce({ RecordsetCount: 0, Record: null });
+
+      const result = await handleSupplierTool("quickfile_supplier_search", {});
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        totalRecords: 0,
+        count: 0,
+        suppliers: [],
+      });
+    });
   });
 
   describe("quickfile_supplier_create", () => {


### PR DESCRIPTION
## Summary

Added unit coverage proving Supplier_Search responses with Record: null normalize to an empty suppliers array, complementing the existing SupplierSearchResponse null type.

## Files Changed

tests/unit/supplier.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- --runTestsByPath tests/unit/supplier.test.ts; npm run typecheck

Resolves #93


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.55 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 3m and 44,062 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for edge case handling in supplier search functionality when no results are returned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->