### PR TITLE
fix: warn on invalid supplier country

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -699,8 +699,12 @@ export function buildSupplierAddressFields(
   const country = rawCountry?.trim().toUpperCase();
   // QuickFile expects ISO-3166-1 alpha-2 values; ignore unrecognised input
   // instead of throwing so supplier creation can still use other valid fields.
-  if (country && VALID_ISO_ALPHA2_CODES.has(country)) {
-    fields.CountryISO = country;
+  if (country) {
+    if (VALID_ISO_ALPHA2_CODES.has(country)) {
+      fields.CountryISO = country;
+    } else {
+      logger.warn("Ignored unrecognised country code", { country });
+    }
   }
 
   return fields;

--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -179,28 +179,41 @@ describe("Supplier tools", () => {
     });
 
     it("accepts legacy country only when it is a valid two-letter ISO code", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
       mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
       await handleSupplierTool("quickfile_supplier_create", {
         companyName: "Acme",
         country: "United Kingdom",
       });
       expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[WARN] Ignored unrecognised country code {"country":"UNITED KINGDOM"}',
+      );
 
       mockRequest.mockClear();
+      consoleErrorSpy.mockClear();
       mockRequest.mockResolvedValueOnce({ SupplierID: 2 });
       await handleSupplierTool("quickfile_supplier_create", {
         companyName: "Acme",
         country: "gb",
       });
       expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
 
       mockRequest.mockClear();
+      consoleErrorSpy.mockClear();
       mockRequest.mockResolvedValueOnce({ SupplierID: 3 });
       await handleSupplierTool("quickfile_supplier_create", {
         companyName: "Acme",
         countryIso: "ZZ",
       });
       expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[WARN] Ignored unrecognised country code {"country":"ZZ"}',
+      );
+      consoleErrorSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
Resolves #95

## Summary
- Add a warning log when supplier country input is provided but not recognised as an ISO-3166-1 alpha-2 code.
- Keep existing behaviour of omitting invalid CountryISO values so supplier creation can proceed with other valid fields.
- Cover invalid legacy `country`, valid lower-case `country`, and invalid `countryIso` cases in supplier unit tests.

## Testing
- npm test -- --runTestsByPath tests/unit/supplier.test.ts
- npm run typecheck
- npm run lint

MERGE_SUMMARY: Added supplier invalid-country warning logging in src/tools/utils.ts and unit coverage in tests/unit/supplier.test.ts. Verified with targeted supplier tests, typecheck, and lint.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 3m and 77,725 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved country code validation to provide warning messages when unrecognized country values are encountered, replacing silent failure behavior. Valid ISO country codes continue to be processed correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->