### PR TITLE
fix: centralize supplier response contracts

### DIFF
--- a/src/tools/supplier.ts
+++ b/src/tools/supplier.ts
@@ -6,9 +6,11 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { getApiClient } from "../api/client.js";
 import type {
-  Supplier,
+  SupplierCreateResponse,
+  SupplierGetResponse,
   SupplierSearchParams,
   SupplierSearchResponse,
+  SupplierUpdateResponse,
 } from "../types/quickfile.js";
 import {
   handleToolError,
@@ -141,18 +143,6 @@ export const supplierTools: Tool[] = [
 // =============================================================================
 // Tool Handlers
 // =============================================================================
-
-interface SupplierGetResponse {
-  SupplierDetails: Supplier;
-}
-
-interface SupplierCreateResponse {
-  SupplierID: number;
-}
-
-interface SupplierUpdateResponse {
-  SupplierDetailsUpdated?: boolean;
-}
 
 interface QuickFileRequester {
   request<TRequest, TResponse>(

--- a/src/types/quickfile.ts
+++ b/src/types/quickfile.ts
@@ -91,6 +91,12 @@ export interface QuickFileError {
   ErrorMessage: string;
 }
 
+export interface SearchResponse<T> {
+  RecordsetCount: number;
+  ReturnCount: number;
+  Record?: T | T[] | null;
+}
+
 // =============================================================================
 // Client Types
 // =============================================================================
@@ -332,10 +338,18 @@ export interface SupplierSearchParams {
   OrderDirection?: 'ASC' | 'DESC';
 }
 
-export interface SupplierSearchResponse {
-  RecordsetCount: number;
-  ReturnCount: number;
-  Record?: Supplier | Supplier[] | null;
+export type SupplierSearchResponse = SearchResponse<Supplier>;
+
+export interface SupplierGetResponse {
+  SupplierDetails: Supplier;
+}
+
+export interface SupplierCreateResponse {
+  SupplierID: number;
+}
+
+export interface SupplierUpdateResponse {
+  SupplierDetailsUpdated?: boolean;
 }
 
 export interface SupplierAddressFields {


### PR DESCRIPTION
## Summary
- add reusable SearchResponse<T> for QuickFile list endpoints
- make SupplierSearchResponse an alias of SearchResponse<Supplier>
- move supplier get/create/update response contracts into shared QuickFile types

Resolves #96

## Testing
- npm run typecheck
- npm run lint
- npm test
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.57 plugin for [OpenCode](https://opencode.ai) v1.15.3 with gpt-5.5 spent 2m and 50,838 tokens on this as a headless worker.
