### PR TITLE
GH#101: test: harden supplier country warning test

### DIFF
--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -178,42 +178,45 @@ describe("Supplier tools", () => {
       expect(details).not.toHaveProperty("TermDays");
     });
 
-    it("accepts legacy country only when it is a valid two-letter ISO code", async () => {
+    it("warns on invalid country inputs and accepts valid legacy ISO codes", async () => {
       const consoleErrorSpy = jest
         .spyOn(console, "error")
         .mockImplementation(() => undefined);
-      mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
-      await handleSupplierTool("quickfile_supplier_create", {
-        companyName: "Acme",
-        country: "United Kingdom",
-      });
-      expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[WARN] Ignored unrecognised country code {"country":"UNITED KINGDOM"}',
-      );
+      try {
+        mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
+        await handleSupplierTool("quickfile_supplier_create", {
+          companyName: "Acme",
+          country: "United Kingdom",
+        });
+        expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[WARN] Ignored unrecognised country code {"country":"UNITED KINGDOM"}',
+        );
 
-      mockRequest.mockClear();
-      consoleErrorSpy.mockClear();
-      mockRequest.mockResolvedValueOnce({ SupplierID: 2 });
-      await handleSupplierTool("quickfile_supplier_create", {
-        companyName: "Acme",
-        country: "gb",
-      });
-      expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+        mockRequest.mockClear();
+        consoleErrorSpy.mockClear();
+        mockRequest.mockResolvedValueOnce({ SupplierID: 2 });
+        await handleSupplierTool("quickfile_supplier_create", {
+          companyName: "Acme",
+          country: "gb",
+        });
+        expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
 
-      mockRequest.mockClear();
-      consoleErrorSpy.mockClear();
-      mockRequest.mockResolvedValueOnce({ SupplierID: 3 });
-      await handleSupplierTool("quickfile_supplier_create", {
-        companyName: "Acme",
-        countryIso: "ZZ",
-      });
-      expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[WARN] Ignored unrecognised country code {"country":"ZZ"}',
-      );
-      consoleErrorSpy.mockRestore();
+        mockRequest.mockClear();
+        consoleErrorSpy.mockClear();
+        mockRequest.mockResolvedValueOnce({ SupplierID: 3 });
+        await handleSupplierTool("quickfile_supplier_create", {
+          companyName: "Acme",
+          countryIso: "ZZ",
+        });
+        expect(lastPayload().SupplierDetails).not.toHaveProperty("CountryISO");
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[WARN] Ignored unrecognised country code {"country":"ZZ"}',
+        );
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Updated the supplier country warning unit test to describe both legacy and countryIso inputs, and wrapped the console.error spy in try/finally so it is restored even if assertions fail.

## Files Changed

tests/unit/supplier.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- supplier.test.ts; npm run typecheck

Resolves #101


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with gpt-5.5 spent 3m and 77,783 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced unit tests for supplier creation with improved error handling verification and more reliable cleanup mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->