### PR TITLE
test: split supplier country validation cases

### DIFF
--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -178,11 +178,18 @@ describe("Supplier tools", () => {
       expect(details).not.toHaveProperty("TermDays");
     });
 
-    it("warns on invalid country inputs and accepts valid legacy ISO codes", async () => {
-      const consoleErrorSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => undefined);
-      try {
+    describe("country validation", () => {
+      let consoleErrorSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      });
+
+      afterEach(() => {
+        consoleErrorSpy.mockRestore();
+      });
+
+      it("ignores and warns on unrecognised country names", async () => {
         mockRequest.mockResolvedValueOnce({ SupplierID: 1 });
         await handleSupplierTool("quickfile_supplier_create", {
           companyName: "Acme",
@@ -192,9 +199,9 @@ describe("Supplier tools", () => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           '[WARN] Ignored unrecognised country code {"country":"UNITED KINGDOM"}',
         );
+      });
 
-        mockRequest.mockClear();
-        consoleErrorSpy.mockClear();
+      it("accepts and normalizes valid legacy two-letter country codes", async () => {
         mockRequest.mockResolvedValueOnce({ SupplierID: 2 });
         await handleSupplierTool("quickfile_supplier_create", {
           companyName: "Acme",
@@ -202,9 +209,9 @@ describe("Supplier tools", () => {
         });
         expect(lastPayload().SupplierDetails.CountryISO).toBe("GB");
         expect(consoleErrorSpy).not.toHaveBeenCalled();
+      });
 
-        mockRequest.mockClear();
-        consoleErrorSpy.mockClear();
+      it("ignores and warns on unrecognised countryIso codes", async () => {
         mockRequest.mockResolvedValueOnce({ SupplierID: 3 });
         await handleSupplierTool("quickfile_supplier_create", {
           companyName: "Acme",
@@ -214,9 +221,7 @@ describe("Supplier tools", () => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           '[WARN] Ignored unrecognised country code {"country":"ZZ"}',
         );
-      } finally {
-        consoleErrorSpy.mockRestore();
-      }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Refactored the supplier country validation unit coverage into a nested `country validation` describe block.
- Split the combined invalid-name, valid legacy-code, and invalid-ISO assertions into isolated test cases with shared `beforeEach`/`afterEach` spy lifecycle.

## Testing
- `npm test -- --runInBand tests/unit/supplier.test.ts`
- `npm run typecheck`

Resolves #103

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 3m and 74,514 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test structure and coverage for country validation logic with enhanced error handling verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->