### PR TITLE
GH#107: test: isolate supplier request mock

### DIFF
--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -25,6 +25,7 @@ describe("Supplier tools", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRequest.mockReset();
     (getApiClient as jest.Mock).mockReturnValue({ request: mockRequest });
   });
 
@@ -182,7 +183,6 @@ describe("Supplier tools", () => {
       let consoleErrorSpy: jest.SpyInstance;
 
       beforeEach(() => {
-        mockRequest.mockReset();
         consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
       });
 


### PR DESCRIPTION
## Summary

Moved the supplier API request mock reset into the top-level supplier test beforeEach so every test starts with a fresh mock implementation and call queue, then removed the narrower country-validation-only reset.

## Files Changed

tests/unit/supplier.test.ts

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm test -- tests/unit/supplier.test.ts --runInBand; npm run typecheck

Resolves #107


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.12 plugin for [OpenCode](https://opencode.ai) v1.15.6 with gpt-5.5 spent 3m and 41,119 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for supplier module validation to improve test reliability and consistency across test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->