### PR TITLE
test: reset supplier mocks before each test

### DIFF
--- a/tests/unit/supplier.test.ts
+++ b/tests/unit/supplier.test.ts
@@ -24,8 +24,7 @@ describe("Supplier tools", () => {
   const mockRequest = jest.fn();
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    mockRequest.mockReset();
+    jest.resetAllMocks();
     (getApiClient as jest.Mock).mockReturnValue({ request: mockRequest });
   });
 


### PR DESCRIPTION
## Summary
- Replace the supplier test beforeEach clear/reset pair with `jest.resetAllMocks()`.
- Restore the default `getApiClient` mock return value after each reset so tests keep their existing setup.

## Testing
- `npm test -- --runInBand tests/unit/supplier.test.ts`
- `npm run typecheck`

Resolves #111

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.25 plugin for [OpenCode](https://opencode.ai) v1.15.7 with gpt-5.5 spent 2m and 43,527 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to improve mock lifecycle management, ensuring mocks are fully reset during test initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusquinn/quickfile-mcp/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->